### PR TITLE
Downstream builds with code migration script application

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,101 @@
+name: Downstream integration build (GeoWebCache and GeoServer)
+
+on:
+  # trigger on PR, but only on master branch, the checkouts of the downstream projects are also targeting main (default branch)
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Dpom.fmt.skip=true -Dmaven.javadoc.skip=true
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+      - uses: actions/checkout@v4
+      - name: Maven repository caching
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: gt-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            gt-maven-
+      - name: Disable checksum offloading
+        # See: https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760
+        run: |
+          sudo ethtool -K eth0 tx off rx off
+      - name: Build ImageN
+        run: |
+          mvn -B clean install -T1C -DskipTests
+      - name: Checkout GeoTools, GeoWebCache, GeoServer and more
+        run: |
+          cd ~
+          echo "Preparing git ssh checkouts"
+          mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+          echo "Checking out GeoTools"
+          mkdir geotools
+          git clone https://github.com/geotools/geotools.git geotools
+          echo "Checking out GeoWebCache"
+          mkdir geowebcache
+          git clone https://github.com/GeoWebCache/geowebcache.git geowebcache
+          echo "Checking out GeoServer"
+          mkdir geoserver
+          git clone https://github.com/geoserver/geoserver.git geoserver
+          echo "Checking out mapfish-print-v2"
+          mkdir mapfish-print-v2
+          git clone https://github.com/mapfish/mapfish-print-v2.git mapfish-print-v2
+      - name: Build GeoTools v2 with tests
+        run: |
+          cd ~
+          cd geotools
+          git checkout imagen
+          ant -f ${{ github.workspace }}/docs/migration/code-update.xml -Dproject.dir=`pwd`
+          mvn -B clean install -T1C -Dall -DskipTests -fae
+          mvn -B test -T1C -Dall
+      - name: Build GeoWebCache with tests
+        run: |
+          export TEST_OPTS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10"
+          export MAVEN_OPTS="-Xmx1024m $TEST_OPTS"
+          cd ~
+          cd geowebcache/geowebcache
+          git checkout imagen
+          ant -f ${{ github.workspace }}/docs/migration/code-update.xml -Dproject.dir=`pwd`
+          mvn -B install -nsu -Dspotless.apply.skip=true -DskipTests -T1C -fae
+          mvn -B test -fae -nsu -T1C -Dspotless.apply.skip=true
+#      - name: Build Mapfish-print v2 with tests
+#        run: |
+#          cd ~
+#          cd mapfish-print-v2
+#          ant -f docs/migration/code-update.xml -Dproject.dir=`pwd`
+#          git checkout imagen
+#          mvn -B install -nsu -DskipTests -T1C -fae
+#          mvn -B -f pom.xml test -fae -nsu -T1C
+      - name: Build GeoServer with tests
+        run: |
+          echo "Building GeoServer"
+          export TEST_OPTS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10"
+          export MAVEN_OPTS="-Xmx512m $TEST_OPTS"
+          cd ~
+          cd geoserver/src
+          ant -f ${{ github.workspace }}/docs/migration/code-update.xml -Dproject.dir=`pwd`
+          git checkout imagen
+          sed -i "s/<mf.version>2.2.0<\/mf.version>/<mf.version>2.3-SNAPSHOT<\/mf.version>/g" geoserver/src/pom.xml
+          sed -i "s/<gf.version>3.6.0<\/gf.version>/<gf.version>3.6-SNAPSHOT<\/gf.version>/g" geoserver/src/pom.xml
+          mvn -B -f pom.xml install -nsu -Prelease -Dspotless.apply.skip=true -DskipTests -T1C -fae
+          mvn -B -f community/pom.xml install -nsu -DcommunityRelease -Dspotless.apply.skip=true -DskipTests -T1C -fae
+          mvn -B -f src/pom.xml test -fae -T1C -nsu -Dtest.maxHeapSize=512m -Djvm.opts="$TEST_OPTS" -Prelease -Dspotless.apply.skip=true
+      - name: Remove SNAPSHOT jars from repository
+        run: |
+          find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -35,4 +35,3 @@ jobs:
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-~                                                                                

--- a/docs/migration/code-update.xml
+++ b/docs/migration/code-update.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Script to migrate java files to use imagen instead of jai and jai-ext -->
+<project name="imagen-pom-update" default="update">
+    <!-- Use this property to run script on your project location -->
+    <property name="project.dir" location="."/>
+
+    <target name="imports" description="Update common import patterns from jai and jai-ext to imagen">
+        <echo level="info"/>
+        <echo level="info" message="Update jai/jai-ext to imagen in java files"/>
+        <replace dir="${project.dir}" includes="**/*.java" summary="yes">
+            <replacefilter>
+                <replacetoken>com.sun.media.imageioimpl.common.BogusColorSpace</replacetoken>
+                <replacevalue>org.eclipse.imagen.NotAColorSpace</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>BogusColorSpace</replacetoken>
+                <replacevalue>NotAColorSpace</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>com.sun.media.jai</replacetoken>
+                <replacevalue>org.eclipse.imagen.media</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>javax.media.jai</replacetoken>
+                <replacevalue>org.eclipse.imagen</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>it.geosolutions.jaiext</replacetoken>
+                <replacevalue>org.eclipse.imagen.media</replacevalue>
+            </replacefilter>
+        </replace>
+    </target>
+
+    <target name="update" depends="imports" description="Update project in current directory from jai to imagen">
+        <echo level="warning">UPDATE COMPLETED: ${project.dir}</echo>
+        <echo level="info">The update is partial, you might have to fix version numbers and the like</echo>
+    </target>
+</project>

--- a/docs/migration/pom-update.xml
+++ b/docs/migration/pom-update.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Tentative script to migrate pom files to use imagen instead of jai and jai-ext. It's not comprehensive, and
+     it's GT/GWC/GS specific, other projects with different conventions will have to adapt it -->
+<project name="imagen-pom-update" default="update">
+    <!-- Use this property to run script on your project location -->
+    <property name="project.dir" location="."/>
+
+    <target name="pom_jai" description="Update pom.xml to migrate jai to imagen">
+        <echo level="info"/>
+        <echo level="info" message="Update jai to imagen in pom.xml files"/>
+        <!-- Replace jai_core dependency with imagen-core -->
+        <fileset id="pom.files" dir="${project.dir}" includes="**/pom.xml"/>
+        <replaceregexp byline="false" flags="s">
+            <regexp pattern="&lt;dependency&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;groupId&gt;\s*javax\.media\s*&lt;/groupId&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;artifactId&gt;\s*jai_codec\s*&lt;/artifactId&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;/dependency&gt;\s*"/>
+            <substitution expression=""/>
+            <fileset refid="pom.files"/>
+        </replaceregexp>
+        <replaceregexp byline="false" flags="s">
+            <regexp pattern="&lt;dependency&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;groupId&gt;\s*javax\.media\s*&lt;/groupId&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;artifactId&gt;\s*jai_imageio\s*&lt;/artifactId&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;/dependency&gt;\s*"/>
+            <substitution expression=""/>
+            <fileset refid="pom.files"/>
+        </replaceregexp>
+        <replaceregexp byline="false" flags="s">
+            <regexp pattern="&lt;dependency&gt;\s*&lt;groupId&gt;\s*javax\.media\s*&lt;/groupId&gt;\s*&lt;artifactId&gt;\s*jai_core\s*&lt;/artifactId&gt;\s*&lt;version&gt;\s*1\.1\.3\s*&lt;/version&gt;\s*&lt;/dependency&gt;"/>
+            <substitution expression="&lt;dependency&gt;&#10;  &lt;groupId&gt;org.eclipse.imagen&lt;/groupId&gt;&#10;  &lt;artifactId&gt;imagen-core&lt;/artifactId&gt;&#10;  &lt;version&gt;${imagen.version}&lt;/version&gt;&#10;&lt;/dependency&gt;"/>
+            <fileset refid="pom.files"/>
+        </replaceregexp>
+        <replaceregexp byline="false" flags="s">
+            <regexp pattern="&lt;dependency&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;groupId&gt;\s*javax\.media\s*&lt;/groupId&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;artifactId&gt;\s*jai_core\s*&lt;/artifactId&gt;(?:(?!&lt;/version&gt;).)*?&lt;/dependency&gt;"/>
+            <substitution expression="&lt;dependency&gt;&#10;  &lt;groupId&gt;org.eclipse.imagen&lt;/groupId&gt;&#10;  &lt;artifactId&gt;imagen-core&lt;/artifactId&gt;&#10;&lt;/dependency&gt;"/>
+            <fileset refid="pom.files"/>
+        </replaceregexp>
+        <replaceregexp byline="false" flags="gs">
+            <regexp pattern="&lt;dependency&gt;\s*&lt;groupId&gt;\s*it\.geosolutions\.jaiext\.([a-z0-9\-]+)\s*&lt;/groupId&gt;\s*&lt;artifactId&gt;\s*jt-([a-z0-9\-]+)\s*&lt;/artifactId&gt;\s*&lt;version&gt;\s*\$\{jaiext.version\}\s*&lt;/version&gt;\s*&lt;/dependency&gt;"/>
+            <substitution expression="&lt;dependency&gt;&#10;  &lt;groupId&gt;org.eclipse.imagen&lt;/groupId&gt;&#10;  &lt;artifactId&gt;\1&lt;/artifactId&gt;&#10;  &lt;version&gt;${imagen.version}&lt;/version&gt;&#10;&lt;/dependency&gt;"/>
+            <fileset refid="pom.files"/>
+        </replaceregexp>
+        <replaceregexp byline="false" flags="gs">
+            <regexp pattern="&lt;dependency&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;groupId&gt;\s*it\.geosolutions\.jaiext\.([a-z0-9\-]+)\s*&lt;/groupId&gt;(?:(?!&lt;/dependency&gt;).){0,500}?&lt;artifactId&gt;\s*jt-\1\s*&lt;/artifactId&gt;(?:(?!&lt;version&gt;).)*?&lt;/dependency&gt;"/>
+            <substitution expression="&lt;dependency&gt;&#10;  &lt;groupId&gt;org.eclipse.imagen&lt;/groupId&gt;&#10;  &lt;artifactId&gt;\1&lt;/artifactId&gt;&#10;&lt;/dependency&gt;"/>
+            <fileset refid="pom.files"/>
+        </replaceregexp>
+        <replaceregexp byline="false" flags="gs">
+            <regexp pattern="&lt;jaiext\.version&gt;.*&lt;/jaiext\.version&gt;"/>
+            <substitution
+                    expression="&lt;imagen\.version&gt;0.4-SNAPSHOT&lt;/imagen\.version&gt;"/>
+            <fileset refid="pom.files"/>
+        </replaceregexp>
+    </target>
+
+    <target name="update" depends="pom_jai" description="Update project in current directory from jai to imagen">
+        <echo level="warning">UPDATE COMPLETED: ${project.dir}</echo>
+        <echo level="info">The update is partial, you might have to fix version numbers and the like</echo>
+    </target>
+</project>


### PR DESCRIPTION
Addded a build that checks out geotools/gwc/mapfish-print/geoserver, checks out their imagen branch, and runs their build, while running the java code migration script. 
Right now it's not going to pass, but we can use this build to track progress and find other work items.