### PR TITLE
doc: fix a mix of javadoc errors

### DIFF
--- a/legacy/network/network-core/src/main/java/org/eclipse/imagen/RemoteImage.java
+++ b/legacy/network/network-core/src/main/java/org/eclipse/imagen/RemoteImage.java
@@ -409,8 +409,8 @@ public class RemoteImage extends PlanarImage {
      * @param fieldIndex the index of the desired field.
      * @param retries the maximum number of retries; must be positive.
      * @param timeout the timeout interval between retries, in milliseconds; must be positive.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if fieldIndex is negative or >= NUM_VARS.
-     * @throws <code>IllegalArgumentException</code> if retries or timeout is non-positive.
+     * @throws ArrayIndexOutOfBoundsException if fieldIndex is negative or >= NUM_VARS.
+     * @throws IllegalArgumentException if retries or timeout is non-positive.
      */
     protected void requestField(int fieldIndex, int retries, int timeout) {
         if (retries < 0) {
@@ -486,7 +486,7 @@ public class RemoteImage extends PlanarImage {
      * timeout.
      *
      * @param fieldIndex the index of the desired field.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if fieldIndex is negative or >= NUM_VARS.
+     * @throws ArrayIndexOutOfBoundsException if fieldIndex is negative or >= NUM_VARS.
      */
     protected void requestField(int fieldIndex) {
         requestField(fieldIndex, numRetries, timeout);

--- a/modules/bandselect/src/main/java/org/eclipse/imagen/media/bandselect/BandSelectCRIF.java
+++ b/modules/bandselect/src/main/java/org/eclipse/imagen/media/bandselect/BandSelectCRIF.java
@@ -41,7 +41,7 @@ public class BandSelectCRIF extends CRIFImpl {
      * Creates a new instance of <code>BandSelectOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/binarize/src/main/java/org/eclipse/imagen/media/binarize/BinarizeCRIF.java
+++ b/modules/binarize/src/main/java/org/eclipse/imagen/media/binarize/BinarizeCRIF.java
@@ -40,7 +40,7 @@ public class BinarizeCRIF extends CRIFImpl {
      * Creates a new instance of <code>BinarizeOpImage</code> in the rendered layer.
      *
      * @param pb The source image and the input parameters.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock pb, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/border/src/main/java/org/eclipse/imagen/media/border/BorderRIF.java
+++ b/modules/border/src/main/java/org/eclipse/imagen/media/border/BorderRIF.java
@@ -37,7 +37,7 @@ public class BorderRIF implements RenderedImageFactory {
      * Creates a new instance of <code>BorderOpImage</code> in the rendered layer.
      *
      * @param args The source image and the border information
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock pb, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/clamp/src/main/java/org/eclipse/imagen/media/clamp/ClampCRIF.java
+++ b/modules/clamp/src/main/java/org/eclipse/imagen/media/clamp/ClampCRIF.java
@@ -38,7 +38,7 @@ public class ClampCRIF extends CRIFImpl {
      * Creates a new instance of <code>ThresholdOpImage</code> in the rendered layer.
      *
      * @param paramBlock ParameterBlock with the source image and the input parameters.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock paramBlock, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorConvertCRIF.java
+++ b/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorConvertCRIF.java
@@ -44,7 +44,7 @@ public class ColorConvertCRIF extends CRIFImpl {
      * Creates a new instance of <code>ColorConvertOpImage</code>.
      *
      * @param args The source image, destination ColorModel and other optional parameters.
-     * @param hints Optionally contains destination image layout.
+     * @param renderingHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock pb, RenderingHints renderingHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtender.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtender.java
@@ -90,7 +90,7 @@ public abstract class BorderExtender implements Serializable {
      *     the <code>BorderExtender</code>.
      * @param im The <code>PlanarImage</code> which may provide the data with which to fill the border area of the
      *     <code>WritableRaster</code>.
-     * @throws <code>IllegalArgumentException</code> if either parameter is <code>null</code>.
+     * @throws IllegalArgumentException if either parameter is <code>null</code>.
      */
     public abstract void extend(WritableRaster raster, PlanarImage im);
 
@@ -117,8 +117,7 @@ public abstract class BorderExtender implements Serializable {
      * @param extenderType The type of <code>BorderExtender</code> to create. Must be one of the predefined class
      *     constants <code>BORDER_COPY</code>, <code>BORDER_REFLECT</code>, <code>BORDER_WRAP</code>, or <code>
      *     BORDER_ZERO</code>.
-     * @throws <code>IllegalArgumentException</code> if the supplied parameter is not one of the supported predefined
-     *     constants.
+     * @throws IllegalArgumentException if the supplied parameter is not one of the supported predefined constants.
      */
     public static BorderExtender createInstance(int extenderType) {
         switch (extenderType) {

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderConstant.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderConstant.java
@@ -104,9 +104,9 @@ public final class BorderExtenderConstant extends BorderExtender {
      * @param raster The <code>WritableRaster</code> the border area of which is to be filled with constants.
      * @param im The <code>PlanarImage</code> which determines the portion of the <code>WritableRaster</code> <i>not</i>
      *     to be filled.
-     * @throws <code>IllegalArgumentException</code> if either parameter is <code>null</code>.
-     * @throws <code>UnsupportedOperationException</code> if the number of image bands exceeds the number of constants
-     *     and the latter is not unity.
+     * @throws IllegalArgumentException if either parameter is <code>null</code>.
+     * @throws UnsupportedOperationException if the number of image bands exceeds the number of constants and the latter
+     *     is not unity.
      */
     public final void extend(WritableRaster raster, PlanarImage im) {
 

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderCopy.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderCopy.java
@@ -73,7 +73,7 @@ public final class BorderExtenderCopy extends BorderExtender {
      *     pixels of the image.
      * @param im The <code>PlanarImage</code> which will provide the edge data with which to fill the border area of the
      *     <code>WritableRaster</code>.
-     * @throws <code>IllegalArgumentException</code> if either parameter is <code>null</code>.
+     * @throws IllegalArgumentException if either parameter is <code>null</code>.
      */
     public final void extend(WritableRaster raster, PlanarImage im) {
 

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderReflect.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderReflect.java
@@ -171,7 +171,7 @@ public final class BorderExtenderReflect extends BorderExtender {
      *     copies of portions of the specified image.
      * @param im The <code>PlanarImage</code> the data of which is to be reflected and used to fill the <code>
      *     WritableRaster</code> border.
-     * @throws <code>IllegalArgumentException</code> if either parameter is <code>null</code>.
+     * @throws IllegalArgumentException if either parameter is <code>null</code>.
      */
     public final void extend(WritableRaster raster, PlanarImage im) {
 

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderWrap.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderWrap.java
@@ -70,7 +70,7 @@ public class BorderExtenderWrap extends BorderExtender {
      *     image.
      * @param im The <code>PlanarImage</code> which will be copied to fill the border area of the <code>WritableRaster
      *     </code>.
-     * @throws <code>IllegalArgumentException</code> if either parameter is <code>null</code>.
+     * @throws IllegalArgumentException if either parameter is <code>null</code>.
      */
     public final void extend(WritableRaster raster, PlanarImage im) {
 

--- a/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderZero.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/BorderExtenderZero.java
@@ -66,7 +66,7 @@ public final class BorderExtenderZero extends BorderExtender {
      * @param raster The <code>WritableRaster</code> the border area of which is to be filled with zero.
      * @param im The <code>PlanarImage</code> which determines the portion of the <code>WritableRaster</code> <i>not</i>
      *     to be filled.
-     * @throws <code>IllegalArgumentException</code> if either parameter is <code>null</code>.
+     * @throws IllegalArgumentException if either parameter is <code>null</code>.
      */
     public final void extend(WritableRaster raster, PlanarImage im) {
 

--- a/modules/core/src/main/java/org/eclipse/imagen/CollectionImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CollectionImage.java
@@ -269,7 +269,7 @@ public abstract class CollectionImage implements ImageJAI, Collection {
      * <p>The default implementation calls <code>getPropertyNames()</code> and searches the list of names for matches.
      *
      * @return An array of <code>String</code>s giving the valid property names or <code>null</code> if there are none.
-     * @throws <code>IllegalArgumentException</code> if <code>prefix</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>prefix</code> is <code>null</code>.
      */
     public String[] getPropertyNames(String prefix) {
         return PropertyUtil.getPropertyNames(getPropertyNames(), prefix);

--- a/modules/core/src/main/java/org/eclipse/imagen/CollectionOp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/CollectionOp.java
@@ -239,7 +239,7 @@ public class CollectionOp extends CollectionImage implements OperationNode, Prop
      * @param hints The rendering hints. If <code>null</code>, it is assumed that no hints are associated with the
      *     rendering. This parameter is cloned.
      * @param isRenderable Whether the operation is being executed in renderable mode.
-     * @throws <code>IllegalArgumentException</code> if <code>opName</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>opName</code> is <code>null</code>.
      * @since JAI 1.1
      */
     public CollectionOp(
@@ -338,7 +338,7 @@ public class CollectionOp extends CollectionImage implements OperationNode, Prop
      *     parameters. This parameter is cloned.
      * @param hints The rendering hints. If <code>null</code>, it is assumed that no hints are associated with the
      *     rendering. This parameter is cloned.
-     * @throws <code>IllegalArgumentException</code> if <code>opName</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>opName</code> is <code>null</code>.
      */
     public CollectionOp(String opName, ParameterBlock pb, RenderingHints hints) {
         this(null, opName, pb, hints);
@@ -361,7 +361,7 @@ public class CollectionOp extends CollectionImage implements OperationNode, Prop
      * @param opName The operation name. Saved by reference.
      * @param pb The sources and other parameters. If <code>null</code>, it is assumed that this node has no sources and
      *     parameters. This parameter is cloned.
-     * @throws <code>IllegalArgumentException</code> if <code>opName</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>opName</code> is <code>null</code>.
      * @deprecated as of JAI 1.1.
      * @see #CollectionOp(OperationRegistry,String,ParameterBlock,RenderingHints)
      */
@@ -424,7 +424,7 @@ public class CollectionOp extends CollectionImage implements OperationNode, Prop
      * rendered.
      *
      * @param opName The new operation name to be set.
-     * @throws <code>IllegalArgumentException</code> if <code>opName</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>opName</code> is <code>null</code>.
      */
     public synchronized void setOperationName(String opName) {
         nodeSupport.setOperationName(opName);
@@ -1058,7 +1058,7 @@ public class CollectionOp extends CollectionImage implements OperationNode, Prop
      * removeProperty()</code> should be used.
      *
      * @param name a String naming the property to be suppressed.
-     * @throws <code>IllegalArgumentException</code> if <code>name</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>name</code> is <code>null</code>.
      * @since JAI 1.1
      */
     public void suppressProperty(String name) {
@@ -1120,8 +1120,8 @@ public class CollectionOp extends CollectionImage implements OperationNode, Prop
      * Creates the <code>Collection</code> rendering if none yet exists, and returns an array containing all of the
      * elements in this <code>Collection</code> whose runtime type is that of the specified array.
      *
-     * @throws <code>ArrayStoreException</code> if the runtime type of the specified array is not a supertype of the
-     *     runtime type of every element in this <code>Collection</code>.
+     * @throws ArrayStoreException if the runtime type of the specified array is not a supertype of the runtime type of
+     *     every element in this <code>Collection</code>.
      */
     public Object[] toArray(Object[] a) {
         createCollection();

--- a/modules/core/src/main/java/org/eclipse/imagen/ComponentSampleModelJAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/ComponentSampleModelJAI.java
@@ -269,9 +269,9 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param y The Y coordinate of the pixel location.
      * @param obj If non-null, a primitive array in which to return the pixel data.
      * @param data The <code>DataBuffer</code> containing the image data.
-     * @throws <code>ClassCastException</code> if obj is non-null and is not a primitive array of type TransferType.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if the coordinates are not in bounds, or if obj is non-null
-     *     and is not large enough to hold the pixel data.
+     * @throws ClassCastException if obj is non-null and is not a primitive array of type TransferType.
+     * @throws ArrayIndexOutOfBoundsException if the coordinates are not in bounds, or if obj is non-null and is not
+     *     large enough to hold the pixel data.
      */
     public Object getDataElements(int x, int y, Object obj, DataBuffer data) {
 
@@ -399,9 +399,9 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @see #getNumDataElements
      * @see #getTransferType
      * @see java.awt.image.DataBuffer
-     * @throws <code>ClassCastException</code> if obj is non-null and is not a primitive array of type TransferType.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if the coordinates are not in bounds, or if obj is non-null
-     *     and is not large enough to hold the pixel data.
+     * @throws ClassCastException if obj is non-null and is not a primitive array of type TransferType.
+     * @throws ArrayIndexOutOfBoundsException if the coordinates are not in bounds, or if obj is non-null and is not
+     *     large enough to hold the pixel data.
      */
     public Object getDataElements(int x, int y, int w, int h, Object obj, DataBuffer data) {
 
@@ -570,9 +570,9 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param y The Y coordinate of the pixel location.
      * @param obj A primitive array containing pixel data.
      * @param data The <code>DataBuffer</code> containing the image data.
-     * @throws <code>ClassCastException</code> if obj is non-null and is not a primitive array of type TransferType.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if the coordinates are not in bounds, or if obj is non-null
-     *     and is not large enough to hold the pixel data.
+     * @throws ClassCastException if obj is non-null and is not a primitive array of type TransferType.
+     * @throws ArrayIndexOutOfBoundsException if the coordinates are not in bounds, or if obj is non-null and is not
+     *     large enough to hold the pixel data.
      */
     public void setDataElements(int x, int y, Object obj, DataBuffer data) {
 
@@ -664,9 +664,9 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param h The height of the pixel rectangle.
      * @param obj A primitive array containing pixel data.
      * @param data The <code>DataBuffer</code> containing the image data.
-     * @throws <code>ClassCastException</code> if obj is non-null and is not a primitive array of type TransferType.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if the coordinates are not in bounds, or if obj is non-null
-     *     and is not large enough to hold the pixel data.
+     * @throws ClassCastException if obj is non-null and is not a primitive array of type TransferType.
+     * @throws ArrayIndexOutOfBoundsException if the coordinates are not in bounds, or if obj is non-null and is not
+     *     large enough to hold the pixel data.
      * @see #getNumDataElements
      * @see #getTransferType
      * @see java.awt.image.DataBuffer
@@ -788,7 +788,7 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param b The band to set.
      * @param s The input sample as a <code>float</code>.
      * @param data The <code>DataBuffer</code> containing the image data.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if coordinates are not in bounds
+     * @throws ArrayIndexOutOfBoundsException if coordinates are not in bounds
      */
     public void setSample(int x, int y, int b, float s, DataBuffer data) {
         data.setElemFloat(bankIndices[b], y * scanlineStride + x * pixelStride + bandOffsets[b], s);
@@ -803,7 +803,7 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param b The band to return.
      * @param data The <code>DataBuffer</code> containing the image data.
      * @return sample The floating point sample value
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if coordinates are not in bounds
+     * @throws ArrayIndexOutOfBoundsException if coordinates are not in bounds
      */
     public float getSampleFloat(int x, int y, int b, DataBuffer data) {
         float sample = data.getElemFloat(bankIndices[b], y * scanlineStride + x * pixelStride + bandOffsets[b]);
@@ -820,7 +820,7 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param b The band to set.
      * @param s The input sample as a <code>double</code>.
      * @param data The <code>DataBuffer</code> containing the image data.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if coordinates are not in bounds
+     * @throws ArrayIndexOutOfBoundsException if coordinates are not in bounds
      */
     public void setSample(int x, int y, int b, double s, DataBuffer data) {
         data.setElemDouble(bankIndices[b], y * scanlineStride + x * pixelStride + bandOffsets[b], s);
@@ -835,7 +835,7 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param b The band to return.
      * @param data The <code>DataBuffer</code> containing the image data.
      * @return sample The <code>double</code> sample value
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if coordinates are not in bounds
+     * @throws ArrayIndexOutOfBoundsException if coordinates are not in bounds
      */
     public double getSampleDouble(int x, int y, int b, DataBuffer data) {
         double sample = data.getElemDouble(bankIndices[b], y * scanlineStride + x * pixelStride + bandOffsets[b]);
@@ -852,7 +852,7 @@ public class ComponentSampleModelJAI extends ComponentSampleModel {
      * @param h The height of the pixel rectangle.
      * @param dArray If non-null, returns the samples in this array.
      * @param data The <code>DataBuffer</code> containing the image data.
-     * @throws <code>ArrayIndexOutOfBoundsException</code> if coordinates are not in bounds
+     * @throws ArrayIndexOutOfBoundsException if coordinates are not in bounds
      */
     public double[] getPixels(int x, int y, int w, int h, double dArray[], DataBuffer data) {
         double pixels[];

--- a/modules/core/src/main/java/org/eclipse/imagen/JAI.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/JAI.java
@@ -451,8 +451,8 @@ public final class JAI {
      * default dimensions.
      *
      * @param tileDimensions The default tile dimensions or <code>null</code>.
-     * @throws <code>IllegalArgumentException</code> if <code>tileDimensions</code> is non-<code>null</code> and has
-     *     non-positive width or height.
+     * @throws IllegalArgumentException if <code>tileDimensions</code> is non-<code>null</code> and has non-positive
+     *     width or height.
      * @since JAI 1.1
      */
     public static final void setDefaultTileSize(Dimension tileDimensions) {
@@ -487,8 +487,8 @@ public final class JAI {
      * which produces a default rendering of height 512 and width 512*aspect_ratio.
      *
      * @param defaultSize The default rendering size or <code>null</code>.
-     * @throws <code>IllegalArgumentException</code> if <code>defaultSize</code> is non-<code>null</code> and both the
-     *     width and height are non-positive.
+     * @throws IllegalArgumentException if <code>defaultSize</code> is non-<code>null</code> and both the width and
+     *     height are non-positive.
      * @since JAI 1.1
      */
     public static final void setDefaultRenderingSize(Dimension defaultSize) {

--- a/modules/core/src/main/java/org/eclipse/imagen/NullOpImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/NullOpImage.java
@@ -73,8 +73,8 @@ public class NullOpImage extends PointOpImage {
      * @param computeType A tag indicating whether the source is <code>OpImage.OP_COMPUTE_BOUND</code>, <code>
      *     OpImage.OP_IO_BOUND</code> or <code>OpImage.OP_NETWORK_BOUND</code>. This information is used as a hint to
      *     optimize <code>OpImage</code> computation.
-     * @throws <code>IllegalArgumentException</code> if <code>source</code> is <code>null</code>.
-     * @throws <code>IllegalArgumentException</code> if <code>computeType</code> is not one of the known <code>
+     * @throws IllegalArgumentException if <code>source</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>computeType</code> is not one of the known <code>
      *     OP_*_BOUND</code> values.
      * @since JAI 1.1
      */

--- a/modules/core/src/main/java/org/eclipse/imagen/PlanarImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/PlanarImage.java
@@ -367,9 +367,9 @@ public abstract class PlanarImage implements ImageJAI, RenderedImage {
      * @param layout an ImageLayout that is used to selectively override the image's layout, <code>SampleModel</code>,
      *     and <code>ColorModel</code>. Only valid fields, i.e., those for which <code>ImageLayout.isValid()</code>
      *     returns <code>true</code> for the appropriate mask, are used.
-     * @throws <code>IllegalArgumentException</code> if <code>layout</code> is <code>null</code>.
-     * @throws <code>IllegalArgumentException</code> if a <code>ColorModel</code> is specified in the layout and it is
-     *     incompatible with the <code>SampleModel</code>
+     * @throws IllegalArgumentException if <code>layout</code> is <code>null</code>.
+     * @throws IllegalArgumentException if a <code>ColorModel</code> is specified in the layout and it is incompatible
+     *     with the <code>SampleModel</code>
      * @since JAI 1.1
      */
     protected void setImageLayout(ImageLayout layout) {

--- a/modules/core/src/main/java/org/eclipse/imagen/RasterFactory.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RasterFactory.java
@@ -787,7 +787,7 @@ public class RasterFactory {
      *     Transparency.TRANSLUCENT</code>. If <code>useAlpha</code> is <code>false</code>, the value of <code>
      *     transparency</code> is ignored. If <code>useAlpha</code> is <code>true</code>, <code>transparency</code> must
      *     not equal <code>Transparency.OPQAUE</code>.
-     * @throws IllegalArgumentExceptionException if <code>colorSpace</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>colorSpace</code> is <code>null</code>.
      * @throws IllegalArgumentException if <code>transparency</code> has an unknown value, if <code>useAlpha == true
      *     </code> but <code>transparency == Transparency.OPAQUE</code>, or if <code>dataType</code> is not one of the
      *     standard types listed above.

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderableOp.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderableOp.java
@@ -798,7 +798,7 @@ public class RenderableOp implements RenderableImage, OperationNode, WritablePro
      * removeProperty()</code> should be used.
      *
      * @param name a String naming the property to be suppressed.
-     * @throws <code>IllegalArgumentException</code> if <code>name</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>name</code> is <code>null</code>.
      */
     public void suppressProperty(String name) {
         nodeSupport.suppressProperty(name);

--- a/modules/core/src/main/java/org/eclipse/imagen/RenderedImageList.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/RenderedImageList.java
@@ -71,10 +71,10 @@ public class RenderedImageList extends CollectionImage implements List, Rendered
     /**
      * Creates a <code>RenderedImageList</code> from the supplied <code>List</code>.
      *
-     * @throws <code>IllegalArgumentException</code> if any objects in the <code>List</code> are not <code>RenderedImage
+     * @throws IllegalArgumentException if any objects in the <code>List</code> are not <code>RenderedImage
      *     </code>s.
-     * @throws <code>IllegalArgumentException</code> if the <code>List</code> is empty.
-     * @throws <code>IllegalArgumentException</code> if the <code>List</code> parameter is <code>null</code>.
+     * @throws IllegalArgumentException if the <code>List</code> is empty.
+     * @throws IllegalArgumentException if the <code>List</code> parameter is <code>null</code>.
      */
     public RenderedImageList(List renderedImageList) {
         super();

--- a/modules/core/src/main/java/org/eclipse/imagen/TiledImage.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TiledImage.java
@@ -497,7 +497,7 @@ public class TiledImage extends PlanarImage implements WritableRenderedImage, Pr
      * from the source image.
      *
      * @param im A <code>RenderedImage</code> source to overlay.
-     * @throws <code>IllegalArgumentException</code> if <code>im</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>im</code> is <code>null</code>.
      */
     public void set(RenderedImage im) {
 
@@ -568,7 +568,7 @@ public class TiledImage extends PlanarImage implements WritableRenderedImage, Pr
      *
      * @param im A <code>RenderedImage</code> source to overlay.
      * @param roi The region of interest.
-     * @throws <code>IllegalArgumentException</code> either parameter is <code>null</code>.
+     * @throws IllegalArgumentException either parameter is <code>null</code>.
      */
     public void set(RenderedImage im, ROI roi) {
 
@@ -803,7 +803,7 @@ public class TiledImage extends PlanarImage implements WritableRenderedImage, Pr
      *
      * @param bandSelect an array of band indices.
      * @param cm the <code>ColorModel</code> of the sub-image.
-     * @throws <code>IllegalArgumentException</code> is <code>bandSelect</code> is <code>null</code>.
+     * @throws IllegalArgumentException is <code>bandSelect</code> is <code>null</code>.
      * @since JAI 1.1
      */
     public TiledImage getSubImage(int[] bandSelect, ColorModel cm) {

--- a/modules/core/src/main/java/org/eclipse/imagen/TiledImageGraphics.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/TiledImageGraphics.java
@@ -150,7 +150,7 @@ class TiledImageGraphics extends Graphics2D {
      * UnsupportedOperationException</code> will be thrown.
      *
      * @param im The <code>TiledImage</code> which will serve as the graphics canvas.
-     * @throws <code>UnsupportedOperationException</code> if no appropriate <code>ColorModel</code> can be derived.
+     * @throws UnsupportedOperationException if no appropriate <code>ColorModel</code> can be derived.
      */
     public TiledImageGraphics(TiledImage im) {
         // Check for non-integral data type.
@@ -258,7 +258,7 @@ class TiledImageGraphics extends Graphics2D {
      * thrown.
      *
      * @return An appropriate <code>ColorModel</code>.
-     * @throws <code>UnsupportedOperationException</code> if no appropriate <code>ColorModel</code> can be derived.
+     * @throws UnsupportedOperationException if no appropriate <code>ColorModel</code> can be derived.
      */
     private static ColorModel getColorModel(TiledImage ti) {
         // Derive an appropriate ColorModel for the BufferedImage:

--- a/modules/core/src/main/java/org/eclipse/imagen/WritablePropertySource.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WritablePropertySource.java
@@ -18,21 +18,17 @@
 package org.eclipse.imagen;
 
 /**
- * Sub-interface of <code>PropertySource</code> which permits setting
- * the values of JAI properties in addition to obtaining their names
- * and values.  As the values of properties managed by classes which
- * implement this interface may change, this is also a sub-interface
- * of <code>PropertyChangeEmitter</code>.  This permits other objects
- * to register as listeners of particular JAI properties.
+ * Sub-interface of <code>PropertySource</code> which permits setting the values of JAI properties in addition to
+ * obtaining their names and values. As the values of properties managed by classes which implement this interface may
+ * change, this is also a sub-interface of <code>PropertyChangeEmitter</code>. This permits other objects to register as
+ * listeners of particular JAI properties.
  *
- * <p> The case of the names of properties added via this interface
- * should be retained although the case will be ignored in queries via
- * <code>getProperty()</code> and will be forced to lower case in
- * emitted <code>PropertySourceChangeEvent<code>.
+ * <p>The case of the names of properties added via this interface should be retained although the case will be ignored
+ * in queries via <code>getProperty()</code> and will be forced to lower case in emitted <code>PropertySourceChangeEvent
+ * </code>.
  *
  * @see PropertySource
  * @see PropertyChangeEmitter
- *
  * @since JAI 1.1
  */
 public interface WritablePropertySource extends PropertySource, PropertyChangeEmitter {

--- a/modules/core/src/main/java/org/eclipse/imagen/WritableRenderedImageAdapter.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/WritableRenderedImageAdapter.java
@@ -48,7 +48,7 @@ public final class WritableRenderedImageAdapter extends RenderedImageAdapter imp
      * Constructs a <code>WritableRenderedImageAdapter</code>.
      *
      * @param im A <code>WritableRenderedImage</code> to be `wrapped' as a <code>PlanarImage</code>.
-     * @throws <code>IllegalArgumentException</code> if <code>im</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>im</code> is <code>null</code>.
      */
     public WritableRenderedImageAdapter(WritableRenderedImage im) {
         super(im);
@@ -59,7 +59,7 @@ public final class WritableRenderedImageAdapter extends RenderedImageAdapter imp
      * Adds an observer. If the observer is already present, it will receive multiple notifications.
      *
      * @param tileObserver The <code>TileObserver</code> to be added.
-     * @throws <code>IllegalArgumentException</code> if <code>tileObserver</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>tileObserver</code> is <code>null</code>.
      */
     public final void addTileObserver(TileObserver tileObserver) {
         if (tileObserver == null) {
@@ -73,7 +73,7 @@ public final class WritableRenderedImageAdapter extends RenderedImageAdapter imp
      * multiple notifications, it will now be registered for one fewer.
      *
      * @param tileObserver The <code>TileObserver</code> to be removed.
-     * @throws <code>IllegalArgumentException</code> if <code>tileObserver</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>tileObserver</code> is <code>null</code>.
      */
     public final void removeTileObserver(TileObserver tileObserver) {
         if (tileObserver == null) {
@@ -144,7 +144,7 @@ public final class WritableRenderedImageAdapter extends RenderedImageAdapter imp
      * Sets a rectangular region of the image to the contents of <code>raster</code>.
      *
      * @param raster A <code>Raster</code>.
-     * @throws <code>IllegalArgumentException</code> if <code>raster</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>raster</code> is <code>null</code>.
      */
     public final void setData(Raster raster) {
         if (raster == null) {

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCollectionCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddCollectionCRIF.java
@@ -42,7 +42,7 @@ public class AddCollectionCRIF extends CRIFImpl {
      * Creates a new instance of <code>AddCollectionOpImage</code> in the rendered layer.
      *
      * @param args A collection of rendered images to be added.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AddConstCRIF.java
@@ -40,7 +40,7 @@ public class AddConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>AddConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/AndConstCRIF.java
@@ -41,7 +41,7 @@ public class AndConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>AndConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandCombineCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandCombineCRIF.java
@@ -41,7 +41,7 @@ public class BandCombineCRIF extends CRIFImpl {
      * Creates a new instance of <code>BandCombineOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandSelectCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BandSelectCRIF.java
@@ -41,7 +41,7 @@ public class BandSelectCRIF extends CRIFImpl {
      * Creates a new instance of <code>BandSelectOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BinarizeCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BinarizeCRIF.java
@@ -41,7 +41,7 @@ public class BinarizeCRIF extends CRIFImpl {
      * Creates a new instance of <code>BinarizeOpImage</code> in the rendered layer.
      *
      * @param args The source image and the input parameters.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BorderRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/BorderRIF.java
@@ -40,7 +40,7 @@ public class BorderRIF implements RenderedImageFactory {
      * Creates a new instance of <code>BorderOpImage</code> in the rendered layer.
      *
      * @param args The source image and the border information
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ClampCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ClampCRIF.java
@@ -41,7 +41,7 @@ public class ClampCRIF extends CRIFImpl {
      * Creates a new instance of <code>ClampOpImage</code> in the rendered layer.
      *
      * @param args The source image and the low and high boundary values.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorConvertCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ColorConvertCRIF.java
@@ -42,7 +42,7 @@ public class ColorConvertCRIF extends CRIFImpl {
      * Creates a new instance of <code>ColorConvertOpImage</code> in the rendered layer.
      *
      * @param args The source image and the destination ColorModel.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CropCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/CropCRIF.java
@@ -44,7 +44,7 @@ public class CropCRIF extends CRIFImpl {
      * Creates a new instance of <code>CropOpImage</code> in the rendered layer.
      *
      * @param args The source image and bounding rectangle
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get the source image.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideByConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideByConstCRIF.java
@@ -41,7 +41,7 @@ public class DivideByConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>DivideByConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideIntoConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/DivideIntoConstCRIF.java
@@ -41,7 +41,7 @@ public class DivideIntoConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>DivideIntoConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LookupCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/LookupCRIF.java
@@ -47,7 +47,7 @@ public class LookupCRIF extends CRIFImpl {
      * Creates a new instance of <code>LookupOpImage</code> in the rendered layer.
      *
      * @param args The source image and the lookup table.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MatchCDFCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MatchCDFCRIF.java
@@ -131,7 +131,7 @@ public class MatchCDFCRIF extends CRIFImpl {
      * Creates a new instance of <code>PiecewiseOpImage</code> in the rendered layer.
      *
      * @param args The source image and the breakpoints.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/MultiplyConstCRIF.java
@@ -41,7 +41,7 @@ public class MultiplyConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>MultiplyConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OrConstCRIF.java
@@ -41,7 +41,7 @@ public class OrConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>OrConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OverlayCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/OverlayCRIF.java
@@ -40,7 +40,7 @@ public class OverlayCRIF extends CRIFImpl {
      * Creates a new instance of <code>OverlayOpImage</code> in the rendered layer.
      *
      * @param args The two source images.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PiecewiseCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/PiecewiseCRIF.java
@@ -41,7 +41,7 @@ public class PiecewiseCRIF extends CRIFImpl {
      * Creates a new instance of <code>PiecewiseOpImage</code> in the rendered layer.
      *
      * @param args The source image and the breakpoints.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RescaleCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/RescaleCRIF.java
@@ -41,7 +41,7 @@ public class RescaleCRIF extends CRIFImpl {
      * Creates a new instance of <code>RescaleOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants (slope, y-intercept).
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractFromConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/SubtractFromConstCRIF.java
@@ -41,7 +41,7 @@ public class SubtractFromConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>SubtractFromConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ThresholdCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/ThresholdCRIF.java
@@ -41,7 +41,7 @@ public class ThresholdCRIF extends CRIFImpl {
      * Creates a new instance of <code>ThresholdOpImage</code> in the rendered layer.
      *
      * @param args The source image and the input parameters.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorConstCRIF.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/media/opimage/XorConstCRIF.java
@@ -41,7 +41,7 @@ public class XorConstCRIF extends CRIFImpl {
      * Creates a new instance of <code>XorConstOpImage</code> in the rendered layer.
      *
      * @param args The source image and the constants.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/nullop/src/main/java/org/eclipse/imagen/media/nullop/NullOpImage.java
+++ b/modules/nullop/src/main/java/org/eclipse/imagen/media/nullop/NullOpImage.java
@@ -70,8 +70,8 @@ public class NullOpImage extends OpImage {
      * @param configuration Configurable attributes of the image including configuration variables indexed by <code>
      *     RenderingHints.Key</code>s and image properties indexed by <code>String</code>s or <code>CaselessStringKey
      *     </code>s. This is simply forwarded to the superclass constructor.
-     * @throws <code>IllegalArgumentException</code> if <code>source</code> is <code>null</code>.
-     * @throws <code>IllegalArgumentException</code> if <code>computeType</code> is not one of the known <code>
+     * @throws IllegalArgumentException if <code>source</code> is <code>null</code>.
+     * @throws IllegalArgumentException if <code>computeType</code> is not one of the known <code>
      *     OP_*_BOUND</code> values.
      */
     public NullOpImage(RenderedImage source, ImageLayout layout, Map configuration) {

--- a/modules/scale2/src/main/java/org/eclipse/imagen/media/scale/Scale2Descriptor.java
+++ b/modules/scale2/src/main/java/org/eclipse/imagen/media/scale/Scale2Descriptor.java
@@ -475,7 +475,7 @@ public class Scale2Descriptor extends OperationDescriptorImpl {
      * @param xTrans The X translation. May be <code>null</code>.
      * @param yTrans The Y translation. May be <code>null</code>.
      * @param interpolation The interpolation method for resampling. May be <code>null</code>.
-     * @param ROI The ROI parameter. May be <code>null</code>.
+     * @param roi The ROI parameter. May be <code>null</code>.
      * @param nodata The nodata Range parameter. May be <code>null</code>.
      * @param backgroundValues The destination no data parameters. May be <code>null</code>.
      * @param hints The <code>RenderingHints</code> to use. May be <code>null</code>.
@@ -528,7 +528,7 @@ public class Scale2Descriptor extends OperationDescriptorImpl {
      * @param xTrans The X translation. May be <code>null</code>.
      * @param yTrans The Y translation. May be <code>null</code>.
      * @param interpolation The interpolation method for resampling. May be <code>null</code>.
-     * @param ROI The ROI parameter. May be <code>null</code>.
+     * @param roi The ROI parameter. May be <code>null</code>.
      * @param nodata The nodata Range parameter. May be <code>null</code>.
      * @param backgroundValues The destination no data parameters. May be <code>null</code>.
      * @param hints The <code>RenderingHints</code> to use. May be <code>null</code>.

--- a/modules/squareroot/src/main/java/org/eclipse/imagen/media/contrastenhancement/SquareRootStretchCRIF.java
+++ b/modules/squareroot/src/main/java/org/eclipse/imagen/media/contrastenhancement/SquareRootStretchCRIF.java
@@ -35,7 +35,7 @@ public class SquareRootStretchCRIF extends CRIFImpl {
      * Creates a new instance of <code>SquareRootStretchOpImage</code> in the rendered layer.
      *
      * @param args The source image and the factors.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock args, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.

--- a/modules/threshold/src/main/java/org/eclipse/imagen/media/threshold/ThresholdCRIF.java
+++ b/modules/threshold/src/main/java/org/eclipse/imagen/media/threshold/ThresholdCRIF.java
@@ -38,7 +38,7 @@ public class ThresholdCRIF extends CRIFImpl {
      * Creates a new instance of <code>ThresholdOpImage</code> in the rendered layer.
      *
      * @param paramBlock ParameterBlock with the source image and the input parameters.
-     * @param hints Optionally contains destination image layout.
+     * @param renderHints Optionally contains destination image layout.
      */
     public RenderedImage create(ParameterBlock paramBlock, RenderingHints renderHints) {
         // Get ImageLayout from renderHints if any.


### PR DESCRIPTION
These are warnings in JDK 11, errors in JDK 17.

There is a lot more javadoc cleanup to go. Just batching to reduce conflicts.