### PR TITLE
Adding jacoco aggregate code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ Use maven to build on the command line:
 
 The build uses the `javac` compiler argument `-XDignore.symbol.file` to reference JDK codecs directly. This functionality is only available from the `javac` command line and requires maven (or your IDE) to fork each call to `javac`.
 
-Maven build QA modules:
+Maven build QA modules (both are applied transparently during the normal build, use manually if needed):
 
     mvn sortpom:sort
     mvn spotless:apply
+
+Building with Jacoco aggregate code coverage:
+
+    mvn clean install -Pjacoco
+    <your_browser> modules/all/target/site/jacoco-aggregate/index.html
 
 ## Supported Java Environment
 

--- a/modules/all/pom.xml
+++ b/modules/all/pom.xml
@@ -326,4 +326,32 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>report-aggregate</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,11 @@
           <artifactId>antlr4-maven-plugin</artifactId>
           <version>4.7.1</version>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.10</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -347,7 +352,29 @@
               </execution>
             </executions>
           </plugin>
-
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <configuration>
+                  <destFile>${project.build.directory}/jacoco.exec</destFile>
+                  <append>true</append>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Added aggregated code coverage. The overall coverage is not bad, around 50%, but the image-core module has a low one:

<img width="1057" height="429" alt="image" src="https://github.com/user-attachments/assets/99c906a0-0a53-4ac9-ad2b-388aab025698" />

More specifically:

<img width="692" height="359" alt="image" src="https://github.com/user-attachments/assets/4395f21c-73e4-4eaf-8f32-22bebf72021c" />

So ok, we can do better already by just moving more operations to legacy (e.g. mosaicopimage should not be there):

<img width="767" height="863" alt="image" src="https://github.com/user-attachments/assets/83348715-3f85-4376-abb0-debc58cea020" />

At the same time, we can use the indication that a class is not used as a hint that we should investigate moving it to legacy
(e.g. GraphicsJAI and CanvasJAI?):

<img width="1198" height="841" alt="image" src="https://github.com/user-attachments/assets/a9ac6e89-d2ce-4c6b-b896-21e2021f68cb" />

My take: let's try to move out as many classes as possible, and then we'll concentrate on getting decent coverage of the classes that are actually in use.

Full report for you to quickly check out, here:
[jacoco-aggregate.zip](https://github.com/user-attachments/files/21505316/jacoco-aggregate.zip)


