### PR TITLE
Explicit use of Thread.yield() to avoid formatter problem with java yield reserved word

### DIFF
--- a/demos/demo/src/main/java/org/eclipse/imagen/demo/JAIDemoPanel.java
+++ b/demos/demo/src/main/java/org/eclipse/imagen/demo/JAIDemoPanel.java
@@ -29,7 +29,7 @@ class AutoThread extends Thread {
             if (!suspended) {
                 panel.animate();
             }
-            yield();
+            Thread.yield();
             try {
                 sleep(10);
             } catch (InterruptedException e) {

--- a/legacy/network/network-demo/src/main/java/org/eclipse/imagen/tutorial/network/JAIDemoPanel.java
+++ b/legacy/network/network-demo/src/main/java/org/eclipse/imagen/tutorial/network/JAIDemoPanel.java
@@ -29,7 +29,7 @@ class AutoThread extends Thread {
             if (!suspended) {
                 panel.animate();
             }
-            yield();
+            Thread.yield();
             try {
                 sleep(10);
             } catch (InterruptedException e) {


### PR DESCRIPTION
Avoids error: `invalid use of a restricted identifier 'yield'` in Java 17 maven environment. 