### PR TITLE
Looking for resources from the app classLoader

### DIFF
--- a/modules/core/src/main/java/org/eclipse/imagen/OperationRegistry.java
+++ b/modules/core/src/main/java/org/eclipse/imagen/OperationRegistry.java
@@ -1574,7 +1574,7 @@ public class OperationRegistry implements Externalizable {
         // the specified class loader.
         Enumeration en;
 
-        if (cl == null) en = ClassLoader.getSystemResources(USR_REGISTRY_FILE);
+        if (cl == null) en = getClass().getClassLoader().getResources(USR_REGISTRY_FILE);
         else en = cl.getResources(USR_REGISTRY_FILE);
 
         while (en.hasMoreElements()) {


### PR DESCRIPTION
@aaime,
I had to do this to have the registryFile.jai being found during the operations registration.

Otherwise, GeoServer classes (GeoTools reader) were reporting the ImageRead operation was not available (being not registered) failing the rendering/loading of the data.
(During a debug of GeoServer deployed in tomcat, that method was always returning an empty enumeration. 

I'm going to integrate it in the code and continue the GT/GS/GWC migration validation so that we can close the other PRs.
Let's review it once you are back.
