### PR TITLE
118: crop/jiffle/vectorize register Spis at JAI OperationRegistry

### DIFF
--- a/modules/crop/src/main/resources/META-INF/services/org.eclipse.imagen.OperationRegistrySpi
+++ b/modules/crop/src/main/resources/META-INF/services/org.eclipse.imagen.OperationRegistrySpi
@@ -1,1 +1,0 @@
-org.eclipse.imagen.media.crop.CropSpi

--- a/modules/jiffle/jt-jiffle-op/src/main/resources/META-INF/services/org.eclipse.imagen.OperationRegistrySpi
+++ b/modules/jiffle/jt-jiffle-op/src/main/resources/META-INF/services/org.eclipse.imagen.OperationRegistrySpi
@@ -1,1 +1,0 @@
-org.eclipse.imagen.media.jiffleop.JiffleSpi

--- a/modules/vectorize/src/main/resources/META-INF/services/org.eclipse.imagen.OperationRegistrySpi
+++ b/modules/vectorize/src/main/resources/META-INF/services/org.eclipse.imagen.OperationRegistrySpi
@@ -1,1 +1,0 @@
-org.jaitools.media.jai.vectorize.VectorizeSpi


### PR DESCRIPTION
closes #118 

crop/jiffle/vectorize register their Spis at JAI, not ImageN. That causes ClassCastExceptions in system where JAI and ImageN are used. 

It seems, removing the ServiceLoader files for these three operators resolves the problem, esp. as they are already registered using `META-INF/registryFile.jai`.