### PR TITLE
Fixing IHS colorConversion issues affecting Gamma Correction

### DIFF
--- a/modules/bandmerge/src/main/java/org/eclipse/imagen/media/bandmerge/BandMergeOpImage.java
+++ b/modules/bandmerge/src/main/java/org/eclipse/imagen/media/bandmerge/BandMergeOpImage.java
@@ -309,7 +309,9 @@ public class BandMergeOpImage extends PointOpImage {
             // Clear the mask bit if incompatible.
             layout.unsetValid(ImageLayout.COLOR_MODEL_MASK);
         }
-        if ((cm == null || !cm.hasAlpha()) && sm instanceof ComponentSampleModel) {
+        // Make sure the bandMerge is only setting the colormodel
+        // when not specified.
+        if (cm == null && sm instanceof ComponentSampleModel) {
             cm = ImageUtilities.getColorModel(sm, setAlpha);
             layout.setColorModel(cm);
         }

--- a/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorConvertOpImage.java
+++ b/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorConvertOpImage.java
@@ -409,20 +409,20 @@ public class ColorConvertOpImage extends PointOpImage {
             // 1. When source and destination color spaces are all ColorSpaceJAI,
             // convert via RGB color space
             case 1:
-                tempRas = computeRectColorSpaceJAIToRGB(source, srcParam, null, tempParam);
-                computeRectColorSpaceJAIFromRGB(tempRas, tempParam, dest, dstParam);
+                tempRas = computeRectColorSpaceJAIToRGB(source, srcParam, null, tempParam, destRect);
+                computeRectColorSpaceJAIFromRGB(tempRas, tempParam, dest, dstParam, destRect);
                 break;
             // when only the source color space is ColorSpaceJAI,
             // 2. if the destination is not RGB, convert to RGB using
             // ColorSpaceJAI; then convert RGB to the destination
             // 3. if the destination is RGB, convert using ColorSpaceJAI
             case 2:
-                tempRas = computeRectColorSpaceJAIToRGB(source, srcParam, null, tempParam);
+                tempRas = computeRectColorSpaceJAIToRGB(source, srcParam, null, tempParam, destRect);
                 computeRectNonColorSpaceJAI(
                         tempRas, tempParam, dest, dstParam, destRect, roiDisjointTile, roiContainsTile, roiIter);
                 break;
             case 3:
-                computeRectColorSpaceJAIToRGB(source, srcParam, dest, dstParam);
+                computeRectColorSpaceJAIToRGB(source, srcParam, dest, dstParam, destRect);
                 break;
             // 4, 5. When only the destination color space is ColorSpaceJAI,
             // similar to the case above.
@@ -430,10 +430,10 @@ public class ColorConvertOpImage extends PointOpImage {
                 tempRas = createTempWritableRaster(source);
                 computeRectNonColorSpaceJAI(
                         source, srcParam, tempRas, tempParam, destRect, roiDisjointTile, roiContainsTile, roiIter);
-                computeRectColorSpaceJAIFromRGB(tempRas, tempParam, dest, dstParam);
+                computeRectColorSpaceJAIFromRGB(tempRas, tempParam, dest, dstParam, destRect);
                 break;
             case 5:
-                computeRectColorSpaceJAIFromRGB(source, srcParam, dest, dstParam);
+                computeRectColorSpaceJAIFromRGB(source, srcParam, dest, dstParam, destRect);
                 break;
             // 6. If all the color space are not ColorSpaceJAI
             case 6:
@@ -450,7 +450,7 @@ public class ColorConvertOpImage extends PointOpImage {
     // 2. Convert to RGB.
     // 3. Shift back to [MIN, MAX]
     private WritableRaster computeRectColorSpaceJAIToRGB(
-            Raster src, ImageParameters srcParam, WritableRaster dest, ImageParameters dstParam) {
+            Raster src, ImageParameters srcParam, WritableRaster dest, ImageParameters dstParam, Rectangle destRect) {
         src = convertRasterToUnsigned(src);
 
         ColorSpaceImageN colorSpaceJAI =
@@ -470,7 +470,14 @@ public class ColorConvertOpImage extends PointOpImage {
             }
         }
         dest = colorSpaceJAIExt.toRGB(
-                src, srcParam.getComponentSize(), dest, dstParam.getComponentSize(), roi, nodata, destinationNoData);
+                src,
+                srcParam.getComponentSize(),
+                dest,
+                destRect,
+                dstParam.getComponentSize(),
+                roi,
+                nodata,
+                destinationNoData);
 
         dest = convertRasterToSigned(dest);
         return dest;
@@ -482,7 +489,7 @@ public class ColorConvertOpImage extends PointOpImage {
     // 2. Convert from RGB.
     // 3. Shift back to [MIN, MAX]
     private WritableRaster computeRectColorSpaceJAIFromRGB(
-            Raster src, ImageParameters srcParam, WritableRaster dest, ImageParameters dstParam) {
+            Raster src, ImageParameters srcParam, WritableRaster dest, ImageParameters dstParam, Rectangle destRect) {
         src = convertRasterToUnsigned(src);
         ColorSpaceImageN colorSpaceJAI =
                 (ColorSpaceImageN) dstParam.getColorModel().getColorSpace();
@@ -501,7 +508,14 @@ public class ColorConvertOpImage extends PointOpImage {
             }
         }
         dest = colorSpaceJAIExt.fromRGB(
-                src, srcParam.getComponentSize(), dest, dstParam.getComponentSize(), roi, nodata, destinationNoData);
+                src,
+                srcParam.getComponentSize(),
+                dest,
+                destRect,
+                dstParam.getComponentSize(),
+                roi,
+                nodata,
+                destinationNoData);
 
         dest = convertRasterToSigned(dest);
         return dest;

--- a/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorSpaceImageNExt.java
+++ b/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorSpaceImageNExt.java
@@ -107,6 +107,7 @@ public abstract class ColorSpaceImageNExt extends ColorSpaceImageN {
             Raster src,
             int[] srcComponentSize,
             WritableRaster dest,
+            Rectangle destRect,
             int[] dstComponentSize,
             ROI roi,
             Range nodata,
@@ -149,6 +150,7 @@ public abstract class ColorSpaceImageNExt extends ColorSpaceImageN {
             Raster src,
             int[] srcComponentSize,
             WritableRaster dest,
+            Rectangle destRect,
             int[] dstComponentSize,
             ROI roi,
             Range nodata,
@@ -161,7 +163,7 @@ public abstract class ColorSpaceImageNExt extends ColorSpaceImageN {
 
     @Override
     public WritableRaster fromRGB(Raster src, int[] srcComponentSize, WritableRaster dest, int[] dstComponentSize) {
-        return fromRGB(src, srcComponentSize, dest, dstComponentSize, null, null, null);
+        return fromRGB(src, srcComponentSize, dest, null, dstComponentSize, null, null, null);
     }
 
     @Override
@@ -171,7 +173,7 @@ public abstract class ColorSpaceImageNExt extends ColorSpaceImageN {
 
     @Override
     public WritableRaster toRGB(Raster src, int[] srcComponentSize, WritableRaster dest, int[] dstComponentSize) {
-        return toRGB(src, srcComponentSize, dest, dstComponentSize, null, null, null);
+        return toRGB(src, srcComponentSize, dest, null, dstComponentSize, null, null, null);
     }
 
     /**

--- a/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorSpaceImageNExtWrapper.java
+++ b/modules/colorconvert/src/main/java/org/eclipse/imagen/media/colorconvert/ColorSpaceImageNExtWrapper.java
@@ -17,6 +17,7 @@
 */
 package org.eclipse.imagen.media.colorconvert;
 
+import java.awt.Rectangle;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import org.eclipse.imagen.ColorSpaceImageN;
@@ -68,12 +69,14 @@ public class ColorSpaceImageNExtWrapper extends ColorSpaceImageNExt {
             Raster src,
             int[] srcComponentSize,
             WritableRaster dest,
+            Rectangle destRect,
             int[] dstComponentSize,
             ROI roi,
             Range nodata,
             float[] destNodata) {
         if (isJAIExt) {
-            return csImageNExt.fromRGB(src, srcComponentSize, dest, dstComponentSize, roi, nodata, destNodata);
+            return csImageNExt.fromRGB(
+                    src, srcComponentSize, dest, destRect, dstComponentSize, roi, nodata, destNodata);
         }
         return csImageN.fromRGB(src, srcComponentSize, dest, dstComponentSize);
     }
@@ -98,12 +101,13 @@ public class ColorSpaceImageNExtWrapper extends ColorSpaceImageNExt {
             Raster src,
             int[] srcComponentSize,
             WritableRaster dest,
+            Rectangle destRect,
             int[] dstComponentSize,
             ROI roi,
             Range nodata,
             float[] destNodata) {
         if (isJAIExt) {
-            return csImageNExt.toRGB(src, srcComponentSize, dest, dstComponentSize, roi, nodata, destNodata);
+            return csImageNExt.toRGB(src, srcComponentSize, dest, destRect, dstComponentSize, roi, nodata, destNodata);
         }
         return csImageN.toRGB(src, srcComponentSize, dest, dstComponentSize);
     }


### PR DESCRIPTION
https://github.com/eclipse-imagen/imagen/issues/123

A couple of issues has been spotted in using Gamma Correction in GeoTools, which uses IHS Colorspaces and color conversion operation.

There was a bug changing the colorModel under the hood and some corner cases (at certain scaling/mosaicking) on the image edges, due to the colorConversion operation ignoring the specififed destination rectangle.