### PR TITLE
Bump guava version from 32.0.0-jre to 33.5.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <junit.vintage.version>5.4.1</junit.vintage.version>
     <junit.platform.version>1.3.2</junit.platform.version>
     <commons.io.version>2.14.0</commons.io.version>
-    <guava.version>32.0.0-jre</guava.version>
+    <guava.version>33.5.0-jre</guava.version>
     <jts.version>1.20.0</jts.version>
     <spotless.action>apply</spotless.action>
     <spotless.apply.skip>false</spotless.apply.skip>


### PR DESCRIPTION
ImageN is on guava `32.0.0`
GeoTools was on guava `33.4.8`
This pull request, and this geotools pull request align them both to the latest `33.5.0`:
- https://github.com/geotools/geotools/pull/5435

