### PR TITLE
Mosaic/warp optimize

### DIFF
--- a/modules/crop/src/main/java/org/eclipse/imagen/media/crop/CropCRIF.java
+++ b/modules/crop/src/main/java/org/eclipse/imagen/media/crop/CropCRIF.java
@@ -32,7 +32,6 @@ import java.util.Vector;
 import org.eclipse.imagen.ImageLayout;
 import org.eclipse.imagen.ImageN;
 import org.eclipse.imagen.ROI;
-import org.eclipse.imagen.ROIShape;
 import org.eclipse.imagen.media.mosaic.MosaicDescriptor;
 import org.eclipse.imagen.media.mosaic.MosaicOpImage;
 import org.eclipse.imagen.media.opimage.RIFUtil;
@@ -80,15 +79,17 @@ public class CropCRIF implements RenderedImageFactory {
         Rectangle bounds = new Rectangle2D.Float(x, y, width, height).getBounds();
         // Initialization of the final bounds
         Rectangle finalBounds = bounds;
-        // If roi is present the final bounds are intersected with the ROI object
+        // A ROI reduces the final bounds to the intersection of the two. Only its bounds
+        // contribute, the shape itself is not carried any further.
         if (roi != null) {
             Rectangle roiBounds = roi.getBounds();
-
-            if (finalBounds.contains(roiBounds)) {
-                finalBounds = roiBounds;
-            } else {
-                finalBounds.intersection(roiBounds);
+            // an empty intersection has no image to describe it, report it here rather than let
+            // the layout fail later on a non-positive width
+            if (!finalBounds.intersects(roiBounds)) {
+                throw new IllegalArgumentException("Crop bounds " + finalBounds + " and ROI bounds " + roiBounds
+                        + " are disjoint, the crop would be empty");
             }
+            finalBounds = finalBounds.intersection(roiBounds);
         }
         // The final bounds coordinates are taken
         x = (float) finalBounds.getMinX();
@@ -98,8 +99,6 @@ public class CropCRIF implements RenderedImageFactory {
 
         // If noData are present, the MosaicOpImage is used instead of the crop
         if (noData != null) {
-            // The calculated bounds are taken as an input roi
-            roi = new ROIShape(finalBounds);
             // The source image is taken as a list of data
             List<RenderedImage> listSrc = new Vector<RenderedImage>();
             listSrc.add(image);
@@ -113,18 +112,21 @@ public class CropCRIF implements RenderedImageFactory {
             layout.setMinX(finalBounds.x);
             layout.setMinY(finalBounds.y);
 
-            // Mosaic operation
-            image = new MosaicOpImage(
+            // No ROI is passed. The code used to build one here, new ROIShape(finalBounds), so a
+            // rectangle covering the crop bounds, not a mask: the caller ROI shape was already
+            // reduced to its bounds above. Since the layout is those same bounds, every destination
+            // pixel fell inside it, so it could not exclude anything, it only made the mosaic
+            // rasterize the shape and take the slower per-pixel ROI branch on every tile.
+            return MosaicOpImage.create(
                     listSrc,
                     layout,
                     local,
                     MosaicDescriptor.MOSAIC_TYPE_OVERLAY,
                     null,
-                    new ROI[] {roi},
+                    null,
                     null,
                     destNoData,
                     new Range[] {noData});
-            return image;
         }
 
         // If noData are not present, then the crop operation is performed

--- a/modules/crop/src/test/java/org/eclipse/imagen/media/crop/CropImageTest.java
+++ b/modules/crop/src/test/java/org/eclipse/imagen/media/crop/CropImageTest.java
@@ -67,6 +67,57 @@ public class CropImageTest extends TestBase {
         destNoData = new double[] {127};
     }
 
+    /**
+     * A ROI hanging over the requested bounds reduces them to the intersection, the same way a ROI fully inside them
+     * does. Goes through CropCRIF directly, the descriptor only checks parameters.
+     */
+    @Test
+    public void testRoiPartiallyOverlappingReducesBounds() {
+        Rectangle cropBounds = new Rectangle(0, 0, 50, 50);
+        ROI roi = new ROIShape(new Rectangle(10, 10, 200, 200));
+        assertEquals(new Rectangle(10, 10, 40, 40), cropBoundsOf(cropBounds, roi, false));
+        assertEquals(new Rectangle(10, 10, 40, 40), cropBoundsOf(cropBounds, roi, true));
+    }
+
+    /** A ROI fully inside the requested bounds keeps reducing them to itself. */
+    @Test
+    public void testRoiInsideReducesBoundsToRoi() {
+        Rectangle cropBounds = new Rectangle(0, 0, 50, 50);
+        ROI roi = new ROIShape(new Rectangle(5, 5, 10, 10));
+        assertEquals(new Rectangle(5, 5, 10, 10), cropBoundsOf(cropBounds, roi, false));
+        assertEquals(new Rectangle(5, 5, 10, 10), cropBoundsOf(cropBounds, roi, true));
+    }
+
+    /** A ROI disjoint from the requested bounds leaves nothing to crop, and must say so. */
+    @Test
+    public void testRoiDisjointFails() {
+        Rectangle cropBounds = new Rectangle(0, 0, 50, 50);
+        ROI roi = new ROIShape(new Rectangle(60, 60, 30, 30));
+        for (boolean noData : new boolean[] {false, true}) {
+            try {
+                cropBoundsOf(cropBounds, roi, noData);
+                fail("Expected a failure on a disjoint ROI, nodata used: " + noData);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage(), e.getMessage().contains("disjoint"));
+                assertTrue(e.getMessage(), e.getMessage().contains("width=50"));
+                assertTrue(e.getMessage(), e.getMessage().contains("x=60"));
+            }
+        }
+    }
+
+    /** Bounds of the crop of the shared source over the given rectangle, with the given ROI. */
+    private Rectangle cropBoundsOf(Rectangle cropBounds, ROI roi, boolean noData) {
+        ParameterBlock pb = new ParameterBlock();
+        pb.addSource(source);
+        pb.add((float) cropBounds.x).add((float) cropBounds.y);
+        pb.add((float) cropBounds.width).add((float) cropBounds.height);
+        pb.add(roi);
+        pb.add(noData ? RangeFactory.create(noDataValue, true, noDataValue, true) : null);
+        pb.add(destNoData);
+        RenderedImage cropped = new CropCRIF().create(pb, new RenderingHints(null));
+        return new Rectangle(cropped.getMinX(), cropped.getMinY(), cropped.getWidth(), cropped.getHeight());
+    }
+
     @Test
     public void testCropImagePB() {
         // Parameterblock creation

--- a/modules/iterators/pom.xml
+++ b/modules/iterators/pom.xml
@@ -20,5 +20,16 @@
       <artifactId>imagen-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- RandomIterBenchmark only -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/iterators/src/main/java/org/eclipse/imagen/media/iterators/RandomIterComponentByte.java
+++ b/modules/iterators/src/main/java/org/eclipse/imagen/media/iterators/RandomIterComponentByte.java
@@ -1,0 +1,185 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2026 GeoSolutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.imagen.media.iterators;
+
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import org.eclipse.imagen.PlanarImage;
+import org.eclipse.imagen.iterator.RandomIter;
+
+/**
+ * Cached random iterator specialized for byte {@link ComponentSampleModel} sources: reads the backing {@code byte[]}
+ * arrays directly instead of going through {@link SampleModel#getSample}. The current tile is kept and only re-fetched
+ * when the requested pixel leaves its bounds, so the common warp access pattern (many reads inside one tile) pays no
+ * per-pixel tile lookup.
+ *
+ * <p>Reads are cheap here, tile switches are not. That fits how warp, scale and affine read: the source point moves a
+ * little at a time, so one tile serves many reads. A caller that jumps to a new tile on almost every read should build
+ * a {@link RandomIterFallbackByte} instead, because {@link RandomIterFactory} always picks this one for a byte source.
+ * RandomIterBenchmark, in the test sources, measures both cases.
+ */
+public class RandomIterComponentByte implements RandomIter {
+
+    /** True when the factory can use this iterator for the given source. */
+    public static boolean applies(RenderedImage im) {
+        SampleModel sm = im.getSampleModel();
+        return sm instanceof ComponentSampleModel && sm.getDataType() == DataBuffer.TYPE_BYTE;
+    }
+
+    private final RenderedImage im;
+
+    private final int tileWidth;
+    private final int tileHeight;
+    private final int tileGridXOffset;
+    private final int tileGridYOffset;
+    private final int imageMinX;
+    private final int imageMinY;
+    private final int imageMaxX;
+    private final int imageMaxY;
+
+    private final int pixelStride;
+    private final int scanlineStride;
+    private final int[] bandOffsets;
+    private final int[] bankIndices;
+
+    /** Backing arrays for the current tile, one per band (may share the same array across bands). */
+    private final byte[][] bankData;
+    /** Per-band base offset: DataBuffer bank offset plus band offset, minus sample-model translate. */
+    private final int[] bandBase;
+
+    private int scanlineBase;
+
+    // Half-open bounds of the current tile; a request outside triggers a tile switch.
+    private int curMinX = Integer.MAX_VALUE;
+    private int curMaxX = Integer.MIN_VALUE;
+    private int curMinY = Integer.MAX_VALUE;
+    private int curMaxY = Integer.MIN_VALUE;
+
+    public RandomIterComponentByte(RenderedImage im) {
+        this.im = im;
+        this.tileWidth = im.getTileWidth();
+        this.tileHeight = im.getTileHeight();
+        this.tileGridXOffset = im.getTileGridXOffset();
+        this.tileGridYOffset = im.getTileGridYOffset();
+        this.imageMinX = im.getMinX();
+        this.imageMinY = im.getMinY();
+        this.imageMaxX = im.getMinX() + im.getWidth();
+        this.imageMaxY = im.getMinY() + im.getHeight();
+
+        ComponentSampleModel sm = (ComponentSampleModel) im.getSampleModel();
+        this.pixelStride = sm.getPixelStride();
+        this.scanlineStride = sm.getScanlineStride();
+        this.bandOffsets = sm.getBandOffsets();
+        this.bankIndices = sm.getBankIndices();
+        this.bankData = new byte[bandOffsets.length][];
+        this.bandBase = new int[bandOffsets.length];
+    }
+
+    /**
+     * Fetches the tile holding (x, y), caches its arrays and bounds, and precomputes the per-band base offset so
+     * {@link #getSample} is a single array read.
+     */
+    private void switchTile(int x, int y) {
+        // A tile at the edge can extend past the image, and that extra area holds no image data, so
+        // being inside a tile is not enough. Checked here, so only tile switches pay for it. The
+        // other iterators fail on the same reads, from their tile index arrays.
+        if (x < imageMinX || x >= imageMaxX || y < imageMinY || y >= imageMaxY) {
+            throw new ArrayIndexOutOfBoundsException("Point " + x + ", " + y + " is outside the image bounds");
+        }
+        int tileX = PlanarImage.XToTileX(x, tileGridXOffset, tileWidth);
+        int tileY = PlanarImage.YToTileY(y, tileGridYOffset, tileHeight);
+        Raster tile = im.getTile(tileX, tileY);
+
+        DataBufferByte db = (DataBufferByte) tile.getDataBuffer();
+        int transX = tile.getSampleModelTranslateX();
+        int transY = tile.getSampleModelTranslateY();
+        int[] dbOffsets = db.getOffsets();
+        // one getBankData call, not one getData per band: each getData marks the buffer untrackable,
+        // which costs more than it saves, see RandomIterBenchmark
+        byte[][] banks = db.getBankData();
+        for (int b = 0; b < bandBase.length; b++) {
+            bankData[b] = banks[bankIndices[b]];
+            bandBase[b] = dbOffsets[bankIndices[b]] + bandOffsets[b] - transX * pixelStride;
+        }
+        this.scanlineBase = -transY * scanlineStride;
+
+        // Clipped to the image, so a read past the edge leaves this window and comes back through
+        // the check above, instead of reading the empty area of an edge tile.
+        this.curMinX = PlanarImage.tileXToX(tileX, tileGridXOffset, tileWidth);
+        this.curMinY = PlanarImage.tileYToY(tileY, tileGridYOffset, tileHeight);
+        this.curMaxX = Math.min(curMinX + tileWidth, imageMaxX);
+        this.curMaxY = Math.min(curMinY + tileHeight, imageMaxY);
+    }
+
+    public int getSample(int x, int y, int b) {
+        if (x < curMinX || x >= curMaxX || y < curMinY || y >= curMaxY) {
+            switchTile(x, y);
+        }
+        int index = scanlineBase + y * scanlineStride + x * pixelStride + bandBase[b];
+        return bankData[b][index] & 0xFF;
+    }
+
+    public float getSampleFloat(int x, int y, int b) {
+        return getSample(x, y, b);
+    }
+
+    public double getSampleDouble(int x, int y, int b) {
+        return getSample(x, y, b);
+    }
+
+    public int[] getPixel(int x, int y, int[] iArray) {
+        if (iArray == null) {
+            iArray = new int[bandOffsets.length];
+        }
+        for (int b = 0; b < bandOffsets.length; b++) {
+            iArray[b] = getSample(x, y, b);
+        }
+        return iArray;
+    }
+
+    public float[] getPixel(int x, int y, float[] fArray) {
+        if (fArray == null) {
+            fArray = new float[bandOffsets.length];
+        }
+        for (int b = 0; b < bandOffsets.length; b++) {
+            fArray[b] = getSample(x, y, b);
+        }
+        return fArray;
+    }
+
+    public double[] getPixel(int x, int y, double[] dArray) {
+        if (dArray == null) {
+            dArray = new double[bandOffsets.length];
+        }
+        for (int b = 0; b < bandOffsets.length; b++) {
+            dArray[b] = getSample(x, y, b);
+        }
+        return dArray;
+    }
+
+    public void done() {
+        for (int b = 0; b < bankData.length; b++) {
+            bankData[b] = null;
+        }
+    }
+}

--- a/modules/iterators/src/main/java/org/eclipse/imagen/media/iterators/RandomIterFactory.java
+++ b/modules/iterators/src/main/java/org/eclipse/imagen/media/iterators/RandomIterFactory.java
@@ -44,6 +44,11 @@ public class RandomIterFactory {
      * set to true, the current tile used by the iterator is cached. If arrayCalculation is set to true an initial array
      * containing the tile position for every pixel is calculated.
      *
+     * <p>A byte {@link java.awt.image.ComponentSampleModel} source with cachedTiles set gets
+     * {@link RandomIterComponentByte}, which builds no per pixel tile table. It uses bounds only to find the image: a
+     * read outside the image fails, one outside bounds but inside the image works. See its javadoc for the access
+     * patterns it suits.
+     *
      * @param im a read-only RenderedImage source.
      * @param bounds the bounding Rectangle for the iterator, or null.
      * @param cachedTiles flag indicating if tiles must be cached during iteration.
@@ -55,6 +60,9 @@ public class RandomIterFactory {
             bounds = new Rectangle(im.getMinX(), im.getMinY(), im.getWidth(), im.getHeight());
         }
         if (arrayCalculation) {
+            if (cachedTiles && RandomIterComponentByte.applies(im)) {
+                return new RandomIterComponentByte(im);
+            }
             if (im.getMinTileX() >= Byte.MIN_VALUE
                     && (im.getMinTileX() + im.getNumXTiles() - 1) <= Byte.MAX_VALUE
                     && im.getMinTileY() >= Byte.MIN_VALUE

--- a/modules/iterators/src/test/java/org/eclipse/imagen/media/iterators/RandomIterBenchmark.java
+++ b/modules/iterators/src/test/java/org/eclipse/imagen/media/iterators/RandomIterBenchmark.java
@@ -1,0 +1,202 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2026 GeoSolutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.imagen.media.iterators;
+
+import java.awt.image.DataBuffer;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.imagen.TiledImage;
+import org.eclipse.imagen.iterator.RandomIter;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH benchmark comparing {@link RandomIterComponentByte} against the {@link RandomIterFallbackByte} it takes over from
+ * in {@link RandomIterFactory}, over the access patterns the resampling operations produce. One operation reads three
+ * bands of {@link #READS} points from a 1024x1024 image tiled at 256, so a full pass crosses every tile.
+ *
+ * <p>Run it with {@code mvn test -pl modules/iterators -Dtest=RandomIterBenchmark#run} after commenting out the
+ * {@link Ignore}; the six combinations take about a minute. The printed JMH table is the output, there is nothing to
+ * assert.
+ *
+ * <p>The patterns, all with the same number of reads. The first two are how the operations read, the third is a stress
+ * case:
+ *
+ * <ul>
+ *   <li>SCAN: row by row, like a scale or a warp that reduced to an affine, which is what small tiles do. Almost every
+ *       read stays in the cached tile.
+ *   <li>WARP: row by row, with each point moved by a few pixels at random. Harder than the real thing: an inverse
+ *       projection moves smoothly from one pixel to the next, it does not jump about.
+ *   <li>RANDOM: anywhere in the image, so almost every read changes tile. No operation reads this way, source points
+ *       always come from a continuous transform. It is here to show the worst case. A caller that did read this way
+ *       should use {@link RandomIterFallbackByte}.
+ * </ul>
+ *
+ * <p>Last measured on JDK 8, ms/op with the JMH 99.9% error, two runs:
+ *
+ * <pre>
+ * pattern       fallback                    component byte              ratio
+ * SCAN      9.98 +- 0.25  10.05 +- 0.91    4.75 +- 0.25   4.61 +- 0.18   2.1x faster
+ * WARP      9.99 +- 0.37   9.99 +- 0.25    9.14 +- 0.47   8.97 +- 0.25   1.1x faster
+ * RANDOM   21.52 +- 4.83  21.64 +- 1.99   38.27 +- 4.21  38.62 +- 12.31  1.8x SLOWER
+ * </pre>
+ *
+ * <p>Reads are cheaper here, tile switches are not, so this iterator wins when many reads share a tile and loses when
+ * they do not. Three guesses about the RANDOM row were measured and dropped: both iterators fetch the same number of
+ * tiles (245753 over the same points), they allocate about the same, and using a shift instead of a division for the
+ * tile index changes nothing. What is left is the work done on each switch, which the fallback skips because it looks
+ * the tile up on every read from its index tables, as stock ImageN does.
+ *
+ * <p>The SCAN ratio mixes two changes, the cached tile and the direct array read, and this benchmark does not tell them
+ * apart. Times depend on the machine, so only differences well over 10% count.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+        value = 1,
+        jvmArgs = {"-Xmx1g"})
+@State(Scope.Benchmark)
+public class RandomIterBenchmark {
+
+    private static final int SIZE = 1024;
+    private static final int TILE = 256;
+    private static final int BANDS = 3;
+
+    /** Points read per operation, enough to cross every tile several times. */
+    private static final int READS = 1 << 20;
+
+    /** The access patterns the resampling operations produce, see the class javadoc. */
+    public enum Pattern {
+        SCAN {
+            void fill(int[] xs, int[] ys, Random random) {
+                for (int i = 0; i < xs.length; i++) {
+                    xs[i] = i % SIZE;
+                    ys[i] = (i / SIZE) % SIZE;
+                }
+            }
+        },
+        WARP {
+            void fill(int[] xs, int[] ys, Random random) {
+                for (int i = 0; i < xs.length; i++) {
+                    xs[i] = clamp(i % SIZE + random.nextInt(7) - 3);
+                    ys[i] = clamp((i / SIZE) % SIZE + random.nextInt(7) - 3);
+                }
+            }
+        },
+        RANDOM {
+            void fill(int[] xs, int[] ys, Random random) {
+                for (int i = 0; i < xs.length; i++) {
+                    xs[i] = random.nextInt(SIZE);
+                    ys[i] = random.nextInt(SIZE);
+                }
+            }
+        };
+
+        abstract void fill(int[] xs, int[] ys, Random random);
+
+        static int clamp(int v) {
+            return Math.max(0, Math.min(SIZE - 1, v));
+        }
+    }
+
+    @Param({"SCAN", "WARP", "RANDOM"})
+    public Pattern pattern;
+
+    private TiledImage image;
+
+    private int[] xs;
+
+    private int[] ys;
+
+    /** Coordinates are precomputed: an operation must measure the reads, not their generation. */
+    @Setup
+    public void setup() {
+        int[] bandOffsets = new int[BANDS];
+        for (int b = 0; b < BANDS; b++) {
+            bandOffsets[b] = b;
+        }
+        image = new TiledImage(
+                0,
+                0,
+                SIZE,
+                SIZE,
+                0,
+                0,
+                new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, TILE, TILE, BANDS, TILE * BANDS, bandOffsets),
+                null);
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                for (int b = 0; b < BANDS; b++) {
+                    image.setSample(x, y, b, (x * 7 + y * 13 + b * 3) & 0xFF);
+                }
+            }
+        }
+        xs = new int[READS];
+        ys = new int[READS];
+        // fixed seed: every run reads the same points, in the same order
+        pattern.fill(xs, ys, new Random(42));
+    }
+
+    @Benchmark
+    public void fallback(Blackhole bh) {
+        readAll(new RandomIterFallbackByte(image, image.getBounds()), bh);
+    }
+
+    @Benchmark
+    public void componentByte(Blackhole bh) {
+        readAll(new RandomIterComponentByte(image), bh);
+    }
+
+    private void readAll(RandomIter iter, Blackhole bh) {
+        int sum = 0;
+        for (int i = 0; i < READS; i++) {
+            int x = xs[i];
+            int y = ys[i];
+            for (int b = 0; b < BANDS; b++) {
+                sum += iter.getSample(x, y, b);
+            }
+        }
+        bh.consume(sum);
+        iter.done();
+    }
+
+    @Test
+    @Ignore("manual benchmark, prints timings rather than asserting")
+    public void run() throws RunnerException {
+        new Runner(new OptionsBuilder().include(getClass().getName()).build()).run();
+    }
+}

--- a/modules/iterators/src/test/java/org/eclipse/imagen/media/iterators/RandomIterTest.java
+++ b/modules/iterators/src/test/java/org/eclipse/imagen/media/iterators/RandomIterTest.java
@@ -19,9 +19,12 @@
 package org.eclipse.imagen.media.iterators;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.awt.image.ComponentSampleModel;
 import java.awt.image.DataBuffer;
+import java.awt.image.PixelInterleavedSampleModel;
 import java.awt.image.RenderedImage;
 import java.awt.image.SampleModel;
 import org.eclipse.imagen.TiledImage;
@@ -325,6 +328,65 @@ public class RandomIterTest {
         if (TEST_SELECTOR == 2) {
             testIteratorSpeed(testImageByte, false, false, SUBSEQUENCY);
         }
+    }
+
+    // Asserts the byte ComponentSampleModel fast iterator matches the generic one on every pixel,
+    // for both single-band and interleaved RGB layouts, across tile boundaries.
+    @Test
+    public void testComponentByteEquivalence() {
+        assertComponentByteMatches(1, 40, 34, 16, 16);
+        assertComponentByteMatches(3, 40, 34, 16, 16);
+    }
+
+    // A 40x34 image tiled at 16x16 has edge tiles hanging over it. Reads landing in that overhang
+    // are outside the image and must fail, as they do on the iterator this one replaces, rather
+    // than return the tile padding.
+    @Test
+    public void testComponentByteRejectsReadsOutsideTheImage() {
+        PixelInterleavedSampleModel sm =
+                new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 40, 34, 1, 40, new int[] {0});
+        TiledImage img = new TiledImage(sm, 16, 16);
+        RandomIter fast = new RandomIterComponentByte(img);
+        // last pixel of the last tile column that is still inside the image
+        assertEquals(0, fast.getSample(39, 5, 0));
+        for (int[] outside : new int[][] {{40, 5}, {45, 5}, {5, 34}, {5, 40}, {-1, 5}, {5, -1}}) {
+            try {
+                fast.getSample(outside[0], outside[1], 0);
+                fail("Expected a failure reading outside the image at " + outside[0] + "," + outside[1]);
+            } catch (ArrayIndexOutOfBoundsException e) {
+                assertTrue(e.getMessage(), e.getMessage().contains("outside the image"));
+            }
+        }
+        fast.done();
+    }
+
+    private void assertComponentByteMatches(int bands, int w, int h, int tileW, int tileH) {
+        int[] bandOffsets = new int[bands];
+        for (int b = 0; b < bands; b++) {
+            bandOffsets[b] = b;
+        }
+        PixelInterleavedSampleModel sm =
+                new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, w, h, bands, w * bands, bandOffsets);
+        TiledImage img = new TiledImage(sm, tileW, tileH);
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                for (int b = 0; b < bands; b++) {
+                    img.setSample(x, y, b, (x * 7 + y * 13 + b * 3) & 0xFF);
+                }
+            }
+        }
+
+        RandomIter fast = new RandomIterComponentByte(img);
+        RandomIter generic = new RandomIterFallbackByte(img, img.getBounds());
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                for (int b = 0; b < bands; b++) {
+                    assertEquals(generic.getSample(x, y, b), fast.getSample(x, y, b));
+                }
+            }
+        }
+        fast.done();
+        generic.done();
     }
 
     /** Simple method for image creation */

--- a/modules/mosaic/pom.xml
+++ b/modules/mosaic/pom.xml
@@ -83,5 +83,16 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- SingleImageMosaicBenchmark only -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/mosaic/src/main/java/org/eclipse/imagen/media/mosaic/MosaicOpImage.java
+++ b/modules/mosaic/src/main/java/org/eclipse/imagen/media/mosaic/MosaicOpImage.java
@@ -81,10 +81,10 @@ public class MosaicOpImage extends OpImage {
     private final int numBands;
 
     /** Bean used for storing image data, ROI, alpha channel, Nodata Range */
-    private final ImageMosaicBean[] imageBeans;
+    final ImageMosaicBean[] imageBeans;
 
     /** Boolean for checking if the ROI is used in the mosaic */
-    private boolean roiPresent;
+    boolean roiPresent;
 
     /**
      * Boolean for checking if the alpha channel is used only for bitmask or for weighting every pixel with is alpha
@@ -99,10 +99,10 @@ public class MosaicOpImage extends OpImage {
     private final BorderExtender sourceBorderExtender;
 
     /** Border extender for the ROI or alpha channel data */
-    private final BorderExtender zeroBorderExtender;
+    final BorderExtender zeroBorderExtender;
 
     /** No data values for the destination image if the pixel of the same location are no Data (Byte) */
-    private byte[] destinationNoDataByte;
+    byte[] destinationNoDataByte;
 
     /** No data values for the destination image if the pixel of the same location are no Data (UShort) */
     private short[] destinationNoDataUShort;
@@ -123,10 +123,10 @@ public class MosaicOpImage extends OpImage {
      * Table used for checking no data values. The first index indicates the source, the second the band, the third the
      * value
      */
-    private final boolean[][][] byteLookupTable;
+    final boolean[][][] byteLookupTable;
 
     /** The format tag for the destination image */
-    private final RasterFormatTag rasterFormatTag;
+    final RasterFormatTag rasterFormatTag;
 
     /** Enumerator for the type of mosaic weigher */
     public enum WeightType {
@@ -414,6 +414,44 @@ public class MosaicOpImage extends OpImage {
             }
         }
         return uniformPalettes;
+    }
+
+    /**
+     * Builds a mosaic over the given sources, picking the fastest implementation that can handle them: same output
+     * whichever one is returned.
+     */
+    public static MosaicOpImage create(
+            List sources,
+            ImageLayout layout,
+            Map renderingHints,
+            MosaicType mosaicTypeSelected,
+            PlanarImage[] alphaImgs,
+            ROI[] rois,
+            double[][] thresholds,
+            double[] destinationNoData,
+            Range[] noDatas) {
+        if (SingleImageMosaicOpImage.applies(sources, mosaicTypeSelected, alphaImgs)) {
+            return new SingleImageMosaicOpImage(
+                    sources,
+                    layout,
+                    renderingHints,
+                    mosaicTypeSelected,
+                    alphaImgs,
+                    rois,
+                    thresholds,
+                    destinationNoData,
+                    noDatas);
+        }
+        return new MosaicOpImage(
+                sources,
+                layout,
+                renderingHints,
+                mosaicTypeSelected,
+                alphaImgs,
+                rois,
+                thresholds,
+                destinationNoData,
+                noDatas);
     }
 
     /**

--- a/modules/mosaic/src/main/java/org/eclipse/imagen/media/mosaic/MosaicRIF.java
+++ b/modules/mosaic/src/main/java/org/eclipse/imagen/media/mosaic/MosaicRIF.java
@@ -40,7 +40,7 @@ public class MosaicRIF implements RenderedImageFactory {
      * defined by the parameterBlock
      */
     public RenderedImage create(ParameterBlock paramBlock, RenderingHints hints) {
-        return new MosaicOpImage(
+        return MosaicOpImage.create(
                 paramBlock.getSources(),
                 RIFUtil.getImageLayoutHint(hints),
                 hints,

--- a/modules/mosaic/src/main/java/org/eclipse/imagen/media/mosaic/SingleImageMosaicOpImage.java
+++ b/modules/mosaic/src/main/java/org/eclipse/imagen/media/mosaic/SingleImageMosaicOpImage.java
@@ -1,0 +1,266 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2026 GeoSolutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.imagen.media.mosaic;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.MultiPixelPackedSampleModel;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.imagen.ImageLayout;
+import org.eclipse.imagen.PlanarImage;
+import org.eclipse.imagen.ROI;
+import org.eclipse.imagen.RasterAccessor;
+import org.eclipse.imagen.RasterFormatTag;
+import org.eclipse.imagen.media.range.Range;
+import org.eclipse.imagen.media.util.ImageUtil;
+
+/**
+ * Fast mosaic for the frequent terminal case of a single byte source composited in OVERLAY mode. Produces the same
+ * output as {@link MosaicOpImage} but walks the destination with direct raster arrays instead of a per-pixel
+ * {@code PixelIterator}, which dominates the generic loop. All setup (ROI, nodata lookup, background) is inherited
+ * unchanged; use {@link MosaicOpImage#create} rather than instantiating this directly.
+ */
+class SingleImageMosaicOpImage extends MosaicOpImage {
+
+    /** False when the ROI image is one the tile loop cannot read, see {@link #canReadRoi}. */
+    private final boolean roiReadable;
+
+    /** False when source or destination data does not come out as byte arrays, see {@link #byteAccessible}. */
+    private final boolean byteAccessors;
+
+    SingleImageMosaicOpImage(
+            List sources,
+            ImageLayout layout,
+            Map renderingHints,
+            MosaicType mosaicTypeSelected,
+            PlanarImage[] alphaImgs,
+            ROI[] rois,
+            double[][] thresholds,
+            double[] destinationNoData,
+            Range[] noDatas) {
+        super(
+                sources,
+                layout,
+                renderingHints,
+                mosaicTypeSelected,
+                alphaImgs,
+                rois,
+                thresholds,
+                destinationNoData,
+                noDatas);
+        RenderedImage roiImage = roiPresent ? imageBeans[0].getRoiImage() : null;
+        this.roiReadable = roiImage == null || canReadRoi(roiImage);
+        this.byteAccessors = byteAccessible(imageBeans[0].getRasterFormatTag()) && byteAccessible(rasterFormatTag);
+    }
+
+    /**
+     * True when RasterAccessor hands out the data of this tag as byte arrays. A sub-byte packed layout (a 4 bit
+     * palette, say) has a byte data type but gets unpacked into int arrays, so the sample model type is not the answer
+     * here.
+     */
+    private static boolean byteAccessible(RasterFormatTag tag) {
+        return (tag.getFormatTagID() & RasterAccessorExt.DATATYPE_MASK) == DataBuffer.TYPE_BYTE;
+    }
+
+    /**
+     * True if the tile loop can read the ROI straight from its raster: bilevel packed bits, or one byte per pixel.
+     * Everything else (a ROI subclass returning a short or int image, say) goes back to the generic mosaic, which reads
+     * any type through Raster.getSample.
+     */
+    private static boolean canReadRoi(RenderedImage roiImage) {
+        SampleModel sm = roiImage.getSampleModel();
+        return sm instanceof MultiPixelPackedSampleModel
+                || (sm instanceof ComponentSampleModel && sm.getDataType() == DataBuffer.TYPE_BYTE);
+    }
+
+    /** Computes a tile from the single source, applying ROI and nodata as background. */
+    @Override
+    public Raster computeTile(int tileX, int tileY) {
+        if (!roiReadable || !byteAccessors) {
+            return super.computeTile(tileX, tileY);
+        }
+        WritableRaster dest = createWritableRaster(getSampleModel(), new Point(tileXToX(tileX), tileYToY(tileY)));
+        Rectangle destRect = getTileRect(tileX, tileY);
+        ImageMosaicBean bean = imageBeans[0];
+
+        PlanarImage source = getSourceImage(0);
+        Rectangle srcRect = destRect.intersection(source.getBounds());
+        RasterAccessor dstAcc = new RasterAccessor(dest, destRect, rasterFormatTag, null);
+
+        // Tiles fully outside the ROI bounding box are pure background, no source read at all. The
+        // bbox test is exact for disjointness and free (no ROI materialization), unlike ROI.contains,
+        // which would force the lazy reprojection-derived ROI to be computed per tile.
+        ROI roi = roiPresent ? bean.getRoi() : null;
+        if (roi != null && !roi.getBounds().intersects(destRect)) {
+            srcRect = new Rectangle();
+        }
+
+        // The source may not cover the whole tile: the pixels it misses take the destination nodata
+        // band by band, which a border extender could not do (it carries a single value).
+        if (!srcRect.equals(destRect)) {
+            fillBackground(dstAcc);
+            // in case it's empty, bail out early
+            if (srcRect.isEmpty()) {
+                dstAcc.copyDataToRaster();
+                return dest;
+            }
+        }
+
+        Raster roiRaster = null;
+        if (roi != null) {
+            roiRaster = PlanarImage.wrapRenderedImage(bean.getRoiImage()).getExtendedData(srcRect, zeroBorderExtender);
+        }
+
+        Raster srcData = source.getData(srcRect);
+        RasterAccessor srcAcc = new RasterAccessorExt(
+                srcData, srcRect, bean.getRasterFormatTag(), bean.getColorModel(), getNumBands(), DataBuffer.TYPE_BYTE);
+
+        overlayByteLoop(srcAcc, dstAcc, roiRaster, bean.getSourceNoData() != null, srcRect);
+        dstAcc.copyDataToRaster();
+
+        // Give the scratch raster back for reuse, as the generic mosaic does. Only when the rect
+        // spans several source tiles: in that case getData allocated and copied, otherwise it
+        // returned a view over live cached tile data, which must not be recycled.
+        if (source.overlapsMultipleTiles(srcData.getBounds())) {
+            recycleTile(srcData);
+        }
+        return dest;
+    }
+
+    /** Fills the whole accessor area with the per band destination nodata. */
+    private void fillBackground(RasterAccessor dst) {
+        byte[][] d = dst.getByteDataArrays();
+        int[] bandOff = dst.getBandOffsets();
+        for (int b = 0; b < d.length; b++) {
+            fillBand(d[b], bandOff[b], dst, destinationNoDataByte[b]);
+        }
+    }
+
+    private static void fillBand(byte[] data, int bandOffset, RasterAccessor dst, byte value) {
+        int line = dst.getScanlineStride();
+        int pix = dst.getPixelStride();
+        int w = dst.getWidth();
+        for (int y = 0; y < dst.getHeight(); y++) {
+            int row = bandOffset + y * line;
+            for (int x = 0; x < w; x++) {
+                data[row + x * pix] = value;
+            }
+        }
+    }
+
+    /** Composites srcRect, a sub area of the destination accessor, the rest is already background. */
+    private void overlayByteLoop(
+            RasterAccessor src, RasterAccessor dst, Raster roi, boolean hasNoData, Rectangle srcRect) {
+        int bands = dst.getNumBands();
+        byte[][] s = src.getByteDataArrays();
+        byte[][] d = dst.getByteDataArrays();
+        int[] sBandOff = src.getBandOffsets();
+        int[] dBandOff = dst.getBandOffsets();
+        int sLine = src.getScanlineStride();
+        int sPix = src.getPixelStride();
+        int dLine = dst.getScanlineStride();
+        int dPix = dst.getPixelStride();
+        int w = srcRect.width;
+        int h = srcRect.height;
+        // offset of the composited area inside the destination accessor
+        int dBase = (srcRect.y - dst.getY()) * dLine + (srcRect.x - dst.getX()) * dPix;
+        boolean[][] lut = byteLookupTable[0];
+
+        // Read the ROI straight from its raster, set up once before the loops. A bilevel ROI is
+        // kept packed (1 bit/pixel, 8 pixels/byte, no expansion); a byte ROI is read from its array.
+        // Normalizing both to a byte per pixel would read better but measured 15% slower, see
+        // SingleImageMosaicBenchmark.
+        boolean hasRoi = roi != null;
+        boolean roiBinary = false;
+        byte[] roiPacked = null;
+        int roiRowBytes = 0;
+        byte[] roiBytes = null;
+        int roiLine = 0;
+        int roiPix = 0;
+        int roiBandOff = 0;
+        if (hasRoi) {
+            SampleModel roiSm = roi.getSampleModel();
+            if (roiSm instanceof MultiPixelPackedSampleModel) {
+                roiBinary = true;
+                roiPacked = ImageUtil.getPackedBinaryData(roi, srcRect);
+                roiRowBytes = (w + 7) / 8; // getPackedBinaryData pads each row to a byte boundary
+            } else {
+                RasterFormatTag tag = new RasterFormatTag(roiSm, RasterAccessor.findCompatibleTag(null, roiSm));
+                RasterAccessor roiAcc = new RasterAccessor(roi, srcRect, tag, null);
+                roiBytes = roiAcc.getByteDataArrays()[0];
+                roiLine = roiAcc.getScanlineStride();
+                roiPix = roiAcc.getPixelStride();
+                roiBandOff = roiAcc.getBandOffsets()[0];
+            }
+        }
+
+        for (int y = 0; y < h; y++) {
+            int sRow = y * sLine;
+            int dRow = dBase + y * dLine;
+            int roiRow = roiBinary ? y * roiRowBytes : roiBandOff + y * roiLine;
+            for (int x = 0; x < w; x++) {
+                int sCol = sRow + x * sPix;
+                boolean background;
+                if (hasRoi && roiZero(roiBinary, roiPacked, roiBytes, roiRow, roiPix, x)) {
+                    background = true;
+                } else if (!hasNoData) {
+                    background = false;
+                } else {
+                    background = true;
+                    for (int b = 0; b < bands; b++) {
+                        if (lut[b][s[b][sBandOff[b] + sCol] & 0xFF]) {
+                            background = false;
+                            break;
+                        }
+                    }
+                }
+                int dCol = dRow + x * dPix;
+                for (int b = 0; b < bands; b++) {
+                    d[b][dBandOff[b] + dCol] = background ? destinationNoDataByte[b] : s[b][sBandOff[b] + sCol];
+                }
+            }
+        }
+    }
+
+    /** True if the ROI is zero (outside) at column x of the current row, reading bits or bytes. */
+    private static boolean roiZero(boolean binary, byte[] packed, byte[] bytes, int rowOffset, int pixelStride, int x) {
+        if (binary) {
+            return ((packed[rowOffset + (x >> 3)] >> (7 - (x & 7))) & 1) == 0;
+        }
+        return bytes[rowOffset + x * pixelStride] == 0;
+    }
+
+    /** True for a single byte source in OVERLAY mode with no alpha: the case this class handles. */
+    static boolean applies(List sources, MosaicType type, PlanarImage[] alphas) {
+        if (sources.size() != 1
+                || type != MosaicDescriptor.MOSAIC_TYPE_OVERLAY
+                || !(alphas == null || alphas.length == 0 || alphas[0] == null)) {
+            return false;
+        }
+        RenderedImage source = (RenderedImage) sources.get(0);
+        return source.getSampleModel().getDataType() == DataBuffer.TYPE_BYTE;
+    }
+}

--- a/modules/mosaic/src/test/java/org/eclipse/imagen/media/mosaic/SingleImageMosaicBenchmark.java
+++ b/modules/mosaic/src/test/java/org/eclipse/imagen/media/mosaic/SingleImageMosaicBenchmark.java
@@ -1,0 +1,213 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2026 GeoSolutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.imagen.media.mosaic;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
+import java.util.Vector;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.imagen.ImageLayout;
+import org.eclipse.imagen.PlanarImage;
+import org.eclipse.imagen.ROI;
+import org.eclipse.imagen.ROIShape;
+import org.eclipse.imagen.media.range.Range;
+import org.eclipse.imagen.media.range.RangeFactory;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH benchmark comparing {@link SingleImageMosaicOpImage} against the generic {@link MosaicOpImage} on the single byte
+ * OVERLAY source case, for each ROI backing the tile loop reads differently. One operation composites a whole 1024x1024
+ * three band image, four 512px tiles.
+ *
+ * <p>Run it with {@code mvn test -pl modules/mosaic -Dtest=SingleImageMosaicBenchmark#run} after commenting out the
+ * {@link Ignore}; the six combinations take about 50 seconds. The printed JMH table is the output, there is nothing to
+ * assert. Run it before and after a change to the tile loop to see what the change cost or gained.
+ *
+ * <p>Last measured on JDK 8, ms/op with the JMH 99.9% error, two runs:
+ *
+ * <pre>
+ * roi              generic                       fast                    speedup
+ * NONE           12.98 +- 1.08  12.80 +- 1.28   8.15 +- 0.46  8.59 +- 1.28  1.5x
+ * PACKED         15.08 +- 2.92  14.66 +- 1.76   9.82 +- 2.06  9.29 +- 1.10  1.6x
+ * BYTE_COMPONENT 12.97 +- 0.68  12.58 +- 0.40   7.40 +- 2.21  7.60 +- 1.21  1.7x
+ * </pre>
+ *
+ * <p>A variant splitting the tile loop per case, the way the rest of the mosaic splits its loops, was measured against
+ * the single loop and landed inside the noise (a few percent either way depending on the ROI), so the single loop
+ * stays.
+ *
+ * <p>Absolute values track the machine and the error stays around 5%, so only differences well over 10% mean anything.
+ * One tried variant measured slower and was dropped: normalizing both ROI layouts to one byte per pixel before the loop
+ * cost 15% on the fast path, the extra pass and allocation being worse than the per-pixel branch they removed.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+// each op allocates 3MB of tile rasters, a small heap turns GC into most of the variance
+@Fork(
+        value = 1,
+        jvmArgs = {"-Xmx1g"})
+@State(Scope.Benchmark)
+public class SingleImageMosaicBenchmark {
+
+    private static final int SIZE = 1024;
+    private static final int TILE = 512;
+
+    /** The three ways the tile loop can read a ROI: not at all, packed bits, one byte per pixel. */
+    public enum RoiKind {
+        NONE {
+            ROI[] create() {
+                return null;
+            }
+        },
+        /** {@link ROIShape} rasterizes to a bilevel, packed image. */
+        PACKED {
+            ROI[] create() {
+                return new ROI[] {new ROIShape(new Rectangle(100, 100, SIZE - 300, SIZE - 300))};
+            }
+        },
+        /**
+         * A byte mask kept byte backed. Plain {@link ROI} binarizes in {@link ROI#getAsImage()}, even when built over a
+         * byte image, so only a subclass that overrides it (GeoTools ROIGeometry) reaches the byte reading branch of
+         * the tile loop.
+         */
+        BYTE_COMPONENT {
+            ROI[] create() {
+                final PlanarImage mask = PlanarImage.wrapRenderedImage(byteMask());
+                return new ROI[] {
+                    new ROI(mask, 1) {
+                        @Override
+                        public PlanarImage getAsImage() {
+                            return mask;
+                        }
+                    }
+                };
+            }
+        };
+
+        abstract ROI[] create();
+
+        static RenderedImage byteMask() {
+            BufferedImage mask = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_BYTE_GRAY);
+            WritableRaster raster = mask.getRaster();
+            for (int y = 0; y < SIZE; y++) {
+                for (int x = 0; x < SIZE; x++) {
+                    boolean inside = x > 100 && x < SIZE - 200 && y > 100 && y < SIZE - 200;
+                    raster.setSample(x, y, 0, inside ? 255 : 0);
+                }
+            }
+            return mask;
+        }
+    }
+
+    @Param({"NONE", "PACKED", "BYTE_COMPONENT"})
+    public RoiKind roi;
+
+    private MosaicOpImage generic;
+
+    private MosaicOpImage fast;
+
+    /**
+     * Both images are built once: {@link MosaicOpImage#computeTile} allocates a fresh raster on every call and never
+     * consults the tile cache, so no operation reuses another one's work.
+     */
+    @Setup
+    public void setup() {
+        RenderedImage source = source();
+        ROI[] rois = roi.create();
+        generic = build(false, source, rois);
+        fast = build(true, source, rois);
+    }
+
+    @Benchmark
+    public void generic(Blackhole bh) {
+        computeAllTiles(generic, bh);
+    }
+
+    @Benchmark
+    public void fast(Blackhole bh) {
+        computeAllTiles(fast, bh);
+    }
+
+    private static void computeAllTiles(MosaicOpImage mosaic, Blackhole bh) {
+        for (int tx = 0; tx < mosaic.getNumXTiles(); tx++) {
+            for (int ty = 0; ty < mosaic.getNumYTiles(); ty++) {
+                bh.consume(mosaic.computeTile(tx, ty));
+            }
+        }
+    }
+
+    private MosaicOpImage build(boolean useFast, RenderedImage source, ROI[] rois) {
+        // MosaicOpImage casts the source list to Vector, no other List will do
+        Vector<RenderedImage> sources = new Vector<>();
+        sources.add(source);
+        ImageLayout layout = new ImageLayout(0, 0, SIZE, SIZE);
+        layout.setTileWidth(TILE);
+        layout.setTileHeight(TILE);
+        double[] destNoData = {255, 255, 255};
+        // nodata is always on: it is the case the crop operation brings to the mosaic
+        Range[] noDatas = {RangeFactory.create((byte) 0, true, (byte) 0, true)};
+        if (useFast) {
+            return new SingleImageMosaicOpImage(
+                    sources, layout, null, MosaicDescriptor.MOSAIC_TYPE_OVERLAY, null, rois, null, destNoData, noDatas);
+        }
+        return new MosaicOpImage(
+                sources, layout, null, MosaicDescriptor.MOSAIC_TYPE_OVERLAY, null, rois, null, destNoData, noDatas);
+    }
+
+    /** Three band byte image with a gradient and a black block that the nodata range catches. */
+    private RenderedImage source() {
+        BufferedImage bi = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_3BYTE_BGR);
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) {
+                boolean blackBlock = x >= 600 && x < 900 && y >= 100 && y < 500;
+                int v = blackBlock ? 0 : Math.max(1, (x + y) % 256);
+                bi.getRaster().setSample(x, y, 0, v);
+                bi.getRaster().setSample(x, y, 1, blackBlock ? 0 : (v + 30) % 256);
+                bi.getRaster().setSample(x, y, 2, blackBlock ? 0 : (v + 60) % 256);
+            }
+        }
+        return PlanarImage.wrapRenderedImage(bi);
+    }
+
+    @Test
+    @Ignore("manual benchmark, prints timings rather than asserting")
+    public void run() throws RunnerException {
+        new Runner(new OptionsBuilder().include(getClass().getName()).build()).run();
+    }
+}

--- a/modules/mosaic/src/test/java/org/eclipse/imagen/media/mosaic/SingleImageMosaicOpImageTest.java
+++ b/modules/mosaic/src/test/java/org/eclipse/imagen/media/mosaic/SingleImageMosaicOpImageTest.java
@@ -1,0 +1,405 @@
+/* JAI-Ext - OpenSource Java Advanced Image Extensions Library
+ *    http://www.geo-solutions.it/
+ *    Copyright 2026 GeoSolutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.imagen.media.mosaic;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.Rectangle;
+import java.awt.image.BandedSampleModel;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.IndexColorModel;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+import org.eclipse.imagen.ImageLayout;
+import org.eclipse.imagen.PlanarImage;
+import org.eclipse.imagen.ROI;
+import org.eclipse.imagen.ROIShape;
+import org.eclipse.imagen.TiledImage;
+import org.eclipse.imagen.media.range.Range;
+import org.eclipse.imagen.media.range.RangeFactory;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link SingleImageMosaicOpImage} produces exactly the same output as the generic {@link MosaicOpImage}
+ * for the single byte OVERLAY source case, with and without ROI and nodata.
+ */
+public class SingleImageMosaicOpImageTest {
+
+    private static final int W = 100;
+    private static final int H = 80;
+
+    @Test
+    public void testPlainCopy() {
+        assertSameAsGeneric(null, null);
+    }
+
+    @Test
+    public void testRoiToBackground() {
+        ROI roi = new ROIShape(new Rectangle(20, 15, 50, 40));
+        assertSameAsGeneric(new ROI[] {roi}, null);
+    }
+
+    @Test
+    public void testNoDataToBackground() {
+        Range black = RangeFactory.create((byte) 0, true, (byte) 0, true);
+        assertSameAsGeneric(null, new Range[] {black});
+    }
+
+    @Test
+    public void testRoiContainingAndDisjointTiles() {
+        // ROI aligned so some 32px tiles fall fully inside (contains: ROI test skipped), some fully
+        // outside (disjoint: pure background), some straddle (per-pixel). Exercises all branches.
+        ROI roi = new ROIShape(new Rectangle(0, 0, 64, 64));
+        Range black = RangeFactory.create((byte) 0, true, (byte) 0, true);
+        assertSameAsGeneric(new ROI[] {roi}, new Range[] {black});
+    }
+
+    @Test
+    public void testRoiAndNoData() {
+        ROI roi = new ROIShape(new Rectangle(20, 15, 50, 40));
+        Range black = RangeFactory.create((byte) 0, true, (byte) 0, true);
+        assertSameAsGeneric(new ROI[] {roi}, new Range[] {black});
+    }
+
+    @Test
+    public void testByteBackedRoi() {
+        // A ROI backed by a byte image, as GeoTools ROIGeometry produces for a reprojection valid
+        // area: exercises the byte array ROI read rather than the packed bit one. Plain ROI is not
+        // enough, its getAsImage binarizes even a byte mask, so getAsImage is overridden here.
+        BufferedImage mask = new BufferedImage(W, H, BufferedImage.TYPE_BYTE_GRAY);
+        for (int y = 0; y < H; y++) {
+            for (int x = 0; x < W; x++) {
+                mask.getRaster().setSample(x, y, 0, (x + y) % 3 == 0 ? 0 : 255);
+            }
+        }
+        final PlanarImage byteMask = PlanarImage.wrapRenderedImage(mask);
+        ROI roi = new ROI(byteMask, 1) {
+            @Override
+            public PlanarImage getAsImage() {
+                return byteMask;
+            }
+        };
+        assertSameAsGeneric(new ROI[] {roi}, null);
+    }
+
+    /**
+     * A ROI covering the whole destination cannot exclude any pixel, so passing it must produce the same output as
+     * passing none. CropCRIF relies on this: it used to hand the mosaic a ROI equal to the crop bounds, which only
+     * forced the per-pixel ROI branch plus a rasterization of the shape.
+     */
+    @Test
+    public void testFullBoundsRoiSameAsNoRoi() {
+        ROI fullBounds = new ROIShape(new Rectangle(0, 0, W, H));
+        Range black = RangeFactory.create((byte) 0, true, (byte) 0, true);
+        assertSamePixels(
+                render(new ROI[] {fullBounds}, new Range[] {black}, layout()),
+                render(null, new Range[] {black}, layout()));
+        assertSamePixels(render(new ROI[] {fullBounds}, null, layout()), render(null, null, layout()));
+    }
+
+    /**
+     * {@link #testFullBoundsRoiSameAsNoRoi} with the bounds offset from the tile grid, so edge tiles hang over them and
+     * the source is larger than the destination on every side. This is the shape CropCRIF actually produces, and the
+     * one case where the two could conceivably differ.
+     */
+    @Test
+    public void testOffsetBoundsRoiSameAsNoRoi() {
+        Rectangle cropBounds = new Rectangle(10, 5, 70, 50);
+        ImageLayout layout = new ImageLayout(cropBounds.x, cropBounds.y, cropBounds.width, cropBounds.height);
+        // tile grid anchored at the origin, not at the crop corner: edge tiles straddle the bounds
+        layout.setTileGridXOffset(0);
+        layout.setTileGridYOffset(0);
+        layout.setTileWidth(32);
+        layout.setTileHeight(32);
+
+        ROI boundsRoi = new ROIShape(cropBounds);
+        Range black = RangeFactory.create((byte) 0, true, (byte) 0, true);
+        assertSamePixels(
+                cropBounds,
+                render(new ROI[] {boundsRoi}, new Range[] {black}, layout),
+                render(null, new Range[] {black}, layout));
+        assertSamePixels(cropBounds, render(new ROI[] {boundsRoi}, null, layout), render(null, null, layout));
+    }
+
+    /**
+     * A destination larger than the source on every side: the pixels the source does not cover must get the destination
+     * nodata band by band, the same values the generic mosaic writes there.
+     */
+    @Test
+    public void testDestinationLargerThanSource() {
+        Range black = RangeFactory.create((byte) 0, true, (byte) 0, true);
+        ROI roi = new ROIShape(new Rectangle(20, 15, 50, 40));
+        assertSameAsGeneric(largerLayout(), null, null);
+        assertSameAsGeneric(largerLayout(), null, new Range[] {black});
+        assertSameAsGeneric(largerLayout(), new ROI[] {roi}, new Range[] {black});
+    }
+
+    /**
+     * A ROI whose image is neither packed bits nor bytes: the tile loop cannot read it, so the fast path must hand the
+     * tile back to the generic mosaic instead of failing.
+     */
+    @Test
+    public void testUnreadableRoiFallsBackToGeneric() {
+        Range black = RangeFactory.create((byte) 0, true, (byte) 0, true);
+        assertSameAsGeneric(new ROI[] {ushortRoi()}, new Range[] {black});
+    }
+
+    /** A single band ushort mask, the shape no known ROI takes, wrapped so getAsImage keeps it. */
+    private ROI ushortRoi() {
+        TiledImage mask = new TiledImage(
+                0,
+                0,
+                W,
+                H,
+                0,
+                0,
+                new PixelInterleavedSampleModel(DataBuffer.TYPE_USHORT, 16, 16, 1, 16, new int[] {0}),
+                null);
+        for (int y = 0; y < H; y++) {
+            for (int x = 0; x < W; x++) {
+                mask.setSample(x, y, 0, x >= 20 && x < 70 && y >= 15 && y < 55 ? 1 : 0);
+            }
+        }
+        return new ROI(mask, 1) {
+            @Override
+            public PlanarImage getAsImage() {
+                return mask;
+            }
+        };
+    }
+
+    private void assertSameAsGeneric(ROI[] rois, Range[] noDatas) {
+        assertSameAsGeneric(layout(), rois, noDatas);
+    }
+
+    /** Runs the comparison over every source layout, the tile loop indexes each one differently. */
+    private void assertSameAsGeneric(ImageLayout layout, ROI[] rois, Range[] noDatas) {
+        for (RenderedImage source : sources()) {
+            String kind = source.getSampleModel().getClass().getSimpleName() + " "
+                    + source.getSampleModel().getNumBands() + " bands at " + source.getMinX() + ","
+                    + source.getMinY();
+            Rectangle area = new Rectangle(
+                    layout.getMinX(null), layout.getMinY(null), layout.getWidth(null), layout.getHeight(null));
+            assertSamePixels(
+                    kind,
+                    area,
+                    generic(source, layout, rois, noDatas).getData(),
+                    fast(source, layout, rois, noDatas).getData());
+        }
+    }
+
+    /** Renders the fast path over the plain three band source, with the given ROI and nodata. */
+    private Raster render(ROI[] rois, Range[] noDatas, ImageLayout layout) {
+        return fast(threeBandSource(), layout, rois, noDatas).getData();
+    }
+
+    private MosaicOpImage generic(RenderedImage source, ImageLayout layout, ROI[] rois, Range[] noDatas) {
+        return new MosaicOpImage(
+                asList(source),
+                layout,
+                null,
+                MosaicDescriptor.MOSAIC_TYPE_OVERLAY,
+                null,
+                rois,
+                null,
+                destNoData(),
+                noDatas);
+    }
+
+    private MosaicOpImage fast(RenderedImage source, ImageLayout layout, ROI[] rois, Range[] noDatas) {
+        return new SingleImageMosaicOpImage(
+                asList(source),
+                layout,
+                null,
+                MosaicDescriptor.MOSAIC_TYPE_OVERLAY,
+                null,
+                rois,
+                null,
+                destNoData(),
+                noDatas);
+    }
+
+    /** MosaicOpImage casts the source list to Vector, no other List will do. */
+    private static Vector<RenderedImage> asList(RenderedImage source) {
+        Vector<RenderedImage> sources = new Vector<>();
+        sources.add(source);
+        return sources;
+    }
+
+    /** Small tiles, so several computeTile calls run including partially covered ones. */
+    private ImageLayout layout() {
+        ImageLayout layout = new ImageLayout(0, 0, W, H);
+        layout.setTileWidth(32);
+        layout.setTileHeight(32);
+        return layout;
+    }
+
+    /** Wraps the source with a 20 pixel margin, so every side has tiles the source misses. */
+    private ImageLayout largerLayout() {
+        ImageLayout layout = new ImageLayout(-20, -20, W + 40, H + 40);
+        layout.setTileWidth(32);
+        layout.setTileHeight(32);
+        return layout;
+    }
+
+    /**
+     * A different value per band, so a background written band-blind cannot pass unnoticed. Longer than any source used
+     * here: MosaicOpImage keeps the first values and drops the rest.
+     */
+    private double[] destNoData() {
+        return new double[] {200, 128, 255, 64};
+    }
+
+    private void assertSamePixels(Raster expected, Raster actual) {
+        assertSamePixels("", new Rectangle(0, 0, W, H), expected, actual);
+    }
+
+    private void assertSamePixels(Rectangle area, Raster expected, Raster actual) {
+        assertSamePixels("", area, expected, actual);
+    }
+
+    private void assertSamePixels(String kind, Rectangle area, Raster expected, Raster actual) {
+        assertEquals(kind + " band count", expected.getNumBands(), actual.getNumBands());
+        for (int y = area.y; y < area.y + area.height; y++) {
+            for (int x = area.x; x < area.x + area.width; x++) {
+                assertSamePixel(kind, expected, actual, x, y);
+            }
+        }
+    }
+
+    private void assertSamePixel(String kind, Raster expected, Raster actual, int x, int y) {
+        for (int b = 0; b < expected.getNumBands(); b++) {
+            assertEquals(
+                    kind + " pixel " + x + "," + y + " band " + b,
+                    expected.getSample(x, y, b),
+                    actual.getSample(x, y, b));
+        }
+    }
+
+    /**
+     * The source layouts whose data the tile loop reaches through different accessor offsets: pixel interleaved, single
+     * band, palette, sub-byte packed palette, and banded with an origin and a tile grid of its own. With a single
+     * source the destination sample model is the source one, so each entry changes the destination layout as well.
+     */
+    private List<RenderedImage> sources() {
+        return Arrays.asList(threeBandSource(), graySource(), paletteSource(), fourBitSource(), bandedSource());
+    }
+
+    /**
+     * Four bit palette source, the shape a paletted GeoTIFF read at its native depth takes. Its sample model reports a
+     * byte data type, but the samples are packed several to a byte, so RasterAccessor unpacks them into int arrays and
+     * the fast tile loop has to hand the tile back to the generic mosaic.
+     */
+    private RenderedImage fourBitSource() {
+        byte[] r = new byte[16];
+        byte[] g = new byte[16];
+        byte[] b = new byte[16];
+        for (int i = 0; i < 16; i++) {
+            r[i] = (byte) (i * 16);
+            g[i] = (byte) (255 - i * 16);
+            b[i] = (byte) ((i * 7) % 256);
+        }
+        IndexColorModel icm = new IndexColorModel(4, 16, r, g, b);
+        BufferedImage bi = new BufferedImage(W, H, BufferedImage.TYPE_BYTE_BINARY, icm);
+        fill(bi, 1);
+        return PlanarImage.wrapRenderedImage(bi);
+    }
+
+    /** Single band gray, so the loop runs with one band and a pixel stride of one. */
+    private RenderedImage graySource() {
+        BufferedImage bi = new BufferedImage(W, H, BufferedImage.TYPE_BYTE_GRAY);
+        fill(bi, 1);
+        return PlanarImage.wrapRenderedImage(bi);
+    }
+
+    /**
+     * Palette source: the nodata lookup is built over palette indexes, not colors. A single source is never expanded to
+     * RGB, MosaicOpImage keeps its sample model as the destination one.
+     */
+    private RenderedImage paletteSource() {
+        // a colored palette, a gray ramp would need no expansion and read back as a single band
+        byte[] r = new byte[256];
+        byte[] g = new byte[256];
+        byte[] b = new byte[256];
+        for (int i = 0; i < 256; i++) {
+            r[i] = (byte) i;
+            g[i] = (byte) (255 - i);
+            b[i] = (byte) ((i * 7) % 256);
+        }
+        IndexColorModel icm = new IndexColorModel(8, 256, r, g, b);
+        BufferedImage bi = new BufferedImage(W, H, BufferedImage.TYPE_BYTE_INDEXED, icm);
+        fill(bi, 1);
+        return PlanarImage.wrapRenderedImage(bi);
+    }
+
+    /**
+     * Three bands in separate banks, origin away from the destination origin and 16 pixel tiles against the 32 pixel
+     * destination ones, so the accessor offsets cannot come out right by accident.
+     */
+    private RenderedImage bandedSource() {
+        // TiledImage takes its tile size from the sample model, hence the 16 pixel one here
+        BandedSampleModel sm = new BandedSampleModel(DataBuffer.TYPE_BYTE, 16, 16, 3);
+        TiledImage image = new TiledImage(7, 3, W, H, 7, 3, sm, null);
+        for (int y = 3; y < H + 3; y++) {
+            for (int x = 7; x < W + 7; x++) {
+                boolean blackBlock = x >= 60 && x < 90 && y >= 10 && y < 50;
+                int v = blackBlock ? 0 : Math.max(1, (x + y) % 256);
+                image.setSample(x, y, 0, v);
+                image.setSample(x, y, 1, blackBlock ? 0 : (v + 30) % 256);
+                image.setSample(x, y, 2, blackBlock ? 0 : (v + 60) % 256);
+            }
+        }
+        return image;
+    }
+
+    /** Gradient with a zero block that the nodata range catches, on every band. */
+    private void fill(BufferedImage bi, int bands) {
+        WritableRaster raster = bi.getRaster();
+        for (int y = 0; y < H; y++) {
+            for (int x = 0; x < W; x++) {
+                boolean blackBlock = x >= 60 && x < 90 && y >= 10 && y < 50;
+                int v = blackBlock ? 0 : Math.max(1, (x + y) % 256);
+                for (int b = 0; b < bands; b++) {
+                    raster.setSample(x, y, b, blackBlock ? 0 : (v + 30 * b) % 256);
+                }
+            }
+        }
+    }
+
+    /** Three band byte image with a gradient and a black (0,0,0) block that acts as nodata. */
+    private RenderedImage threeBandSource() {
+        BufferedImage bi = new BufferedImage(W, H, BufferedImage.TYPE_3BYTE_BGR);
+        for (int y = 0; y < H; y++) {
+            for (int x = 0; x < W; x++) {
+                boolean blackBlock = x >= 60 && x < 90 && y >= 10 && y < 50;
+                int v = blackBlock ? 0 : Math.max(1, (x + y) % 256);
+                bi.getRaster().setSample(x, y, 0, v);
+                bi.getRaster().setSample(x, y, 1, blackBlock ? 0 : (v + 30) % 256);
+                bi.getRaster().setSample(x, y, 2, blackBlock ? 0 : (v + 60) % 256);
+            }
+        }
+        return PlanarImage.wrapRenderedImage(bi);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
     <pom.fmt.action>sort</pom.fmt.action>
     <pom.fmt.skip>${spotless.apply.skip}</pom.fmt.skip>
     <hamcrest.version>3.0</hamcrest.version>
+    <jmh.version>1.37</jmh.version>
   </properties>
 
   <dependencyManagement>
@@ -148,6 +149,19 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- generates the runner classes of the JMH benchmarks -->
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${jmh.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Two changes:
* One to optimize the "single raster mosaic" operation used to apply a Crop with ROI/NoData and to replace nodata/ROI with background values.
* One to optimize byte raster access as observed during warp operations (but generally useful for any operation that does not just randomly bounce around in the raster space of the source).